### PR TITLE
Fix Intel KVM nested virtualization config

### DIFF
--- a/_nixOSModules/hardware/cpu/intel.nix
+++ b/_nixOSModules/hardware/cpu/intel.nix
@@ -28,6 +28,6 @@ in
 
     boot.extraModprobeConfig = lib.mkIf (
       cfg.kvm.enable && cfg.kvm.nestedVirtualization
-    ) "options kvm_amd nested=1";
+    ) "options kvm_intel nested=1";
   };
 }


### PR DESCRIPTION
## Summary
- fix modprobe option for Intel nested virtualization

## Testing
- `nix fmt` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e4a7ad4c8326b6812ffff36d3de2