### PR TITLE
Fix allowed_signers echo

### DIFF
--- a/configs/home/programs/git.nix
+++ b/configs/home/programs/git.nix
@@ -18,7 +18,7 @@ in
   # Generate allowed_signers file at runtime
   home.activation.gitAllowedSigners = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     mkdir -p ${config.xdg.configHome}/git
-    echo "$(cat ${gitUserEmail}) namespaces=\"git\" $(cat ${config.home.homeDirectory}/.ssh/id_ed25519.pub)" > ${config.xdg.configHome}/git/allowed_signers
+    echo "${gitUserEmail} namespaces=\"git\" $(cat ${config.home.homeDirectory}/.ssh/id_ed25519.pub)" > ${config.xdg.configHome}/git/allowed_signers
   '';
 
   programs.git = {


### PR DESCRIPTION
## Summary
- fix `gitAllowedSigners` generation

## Testing
- `bash -c "gitUserEmail='ian.m.holloway@gmail.com'; config_home=$(mktemp -d)/.config; home_dir=$(mktemp -d); mkdir -p $home_dir/.ssh; echo 'ssh-ed25519 AAAAB3NzaC1yc2EAAAADAQABAAABAQCfakekey user@example.com' > $home_dir/.ssh/id_ed25519.pub; mkdir -p $config_home/git; echo \"${gitUserEmail} namespaces=\\\"git\\\" $(cat ${home_dir}/.ssh/id_ed25519.pub)\" > $config_home/git/allowed_signers; cat $config_home/git/allowed_signers"`

------
https://chatgpt.com/codex/tasks/task_e_6866e61379b483268159746344bd5eba