### PR TITLE
fix: address Copilot review findings

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,16 +1,26 @@
 # shellcheck shell=bash
-if has nix_direnv_version || command -v nix >/dev/null 2>&1; then
-  watch_file flake/partitions.nix
-  watch_file flake/dev/flake.nix
-  watch_file flake/dev/formatter.nix
-  watch_file flake/dev/git-hooks.nix
-  watch_file flake/dev/shell.nix
-
-  use flake
-else
-  # direnv is supported on Windows through WSL/Git Bash. When Nix is not
-  # installed, keep the project usable without pretending to provide tools.
+fallback_environment() {
   export NIX_CONF_ROOT="${NIX_CONF_ROOT:-$(pwd)}"
   PATH_add "$NIX_CONF_ROOT/scripts"
   log_status "Nix unavailable; using host tools (no reproducible toolchain loaded)"
+}
+
+watch_file flake/partitions.nix
+watch_file flake/dev/flake.nix
+watch_file flake/dev/formatter.nix
+watch_file flake/dev/git-hooks.nix
+watch_file flake/dev/shell.nix
+
+if has nix_direnv_version; then
+  use flake
+elif command -v nix >/dev/null 2>&1; then
+  if nix_dev_env="$(nix print-dev-env --accept-flake-config 2>/dev/null)" && eval "$nix_dev_env"; then
+    log_status "Loaded reproducible dev environment with nix print-dev-env"
+  else
+    fallback_environment
+  fi
+else
+  # direnv is supported on Windows through WSL/Git Bash. When Nix is not
+  # installed, keep the project usable without pretending to provide tools.
+  fallback_environment
 fi

--- a/.typos.toml
+++ b/.typos.toml
@@ -9,5 +9,9 @@ files.extend-exclude = [
 [default.extend-words]
 ags = "ags"
 Calculater = "Calculater"
+Certificacion = "Certificacion"
+CROS = "CROS"
+HDA = "HDA"
 extens = "extens"
+imput = "imput"
 nd = "nd"

--- a/archive/nixos/desktop/hardware/kernel-patches.nix
+++ b/archive/nixos/desktop/hardware/kernel-patches.nix
@@ -82,8 +82,8 @@ in
         CHARGER_RT9455 = no;
         CHARGER_RT9467 = no;
         CHARGER_RT9471 = no;
-        CHARGER_CROSS_USBPD = no;
-        CHARGER_CROSS_PCHG = no;
+        CHARGER_CROS_USBPD = no;
+        CHARGER_CROS_PCHG = no;
         CHARGER_BD99954 = no;
         CHARGER_WILCO = no;
         BATTERY_SURFACE = no;
@@ -301,12 +301,12 @@ in
         # CHROMEOS_LAPTOP = unset;
         # CHROMEOS_PSTORE = unset;
         # CHROMEOS_TBMC = unset;
-        # CROSS_EC = unset;
-        # CROSS_EC_I2C = unset;
-        # CROSS_EC_ISHTP = unset;
-        # CROSS_EC_LPC = unset;
-        # CROSS_EC_SPI = unset;
-        # CROSS_KBD_LED_BACKLIGHT = unset;
+        # CROS_EC = unset;
+        # CROS_EC_I2C = unset;
+        # CROS_EC_ISHTP = unset;
+        # CROS_EC_LPC = unset;
+        # CROS_EC_SPI = unset;
+        # CROS_KBD_LED_BACKLIGHT = unset;
 
         # SND_SOC = no;
         # SND_SOC_INTEL_SOUNDWIRE_SOF_MACH = unset;
@@ -318,8 +318,8 @@ in
         # SND_SOC_SOF_COMETLAKE = unset;
         # SND_SOC_SOF_ELKHARTLAKE = unset;
         # SND_SOC_SOF_GEMINILAKE = unset;
-        # SND_SOC_SOF_HAD_AUDIO_CODEC = unset;
-        # SND_SOC_SOF_HAD_LINK = unset;
+        # SND_SOC_SOF_HDA_AUDIO_CODEC = unset;
+        # SND_SOC_SOF_HDA_LINK = unset;
         # SND_SOC_SOF_ICELAKE = unset;
         # SND_SOC_SOF_INTEL_TOPLEVEL = unset;
         # SND_SOC_SOF_JASPERLAKE = unset;

--- a/modules/nixos/security/pki.nix
+++ b/modules/nixos/security/pki.nix
@@ -4,7 +4,7 @@
     caCertificateBlacklist = [
       #
       "AC RAIZ FNMT-RCM SERVIDORES SEGUROS"
-      "Autoridad de Certification Firmaprofesional CIF A62634068"
+      "Autoridad de Certificacion Firmaprofesional CIF A62634068"
 
       # China Financial Certification Authority
       "CFCA EV ROOT"

--- a/modules/shared/chromium-policies.nix
+++ b/modules/shared/chromium-policies.nix
@@ -307,7 +307,7 @@ let
             darwinBundleId = mkOption {
               type = types.nullOr types.str;
               default = null;
-              example = "net.input.helium";
+              example = "net.imput.helium";
               description = ''
                 macOS application bundle identifier used for the managed
                 preferences plist.
@@ -317,7 +317,7 @@ let
             darwinExtensionPolicyBundlePrefix = mkOption {
               type = types.nullOr types.str;
               default = null;
-              example = "net.input.helium.extensions";
+              example = "net.imput.helium.extensions";
               description = ''
                 macOS managed preference domain prefix used for extension
                 managed storage policies.
@@ -465,8 +465,8 @@ let
                 "chromium/policies/managed/helium-system.json"
                 "helium/policies/managed/helium-system.json"
               ];
-              darwinBundleId = "net.input.helium";
-              darwinExtensionPolicyBundlePrefix = "net.input.helium.extensions";
+              darwinBundleId = "net.imput.helium";
+              darwinExtensionPolicyBundlePrefix = "net.imput.helium.extensions";
               extensionPolicies = chromiumExtensionPolicies;
             };
           };


### PR DESCRIPTION
Fixes the Copilot findings from #84: robust .envrc Nix capability detection, correct CA and ChromeOS Kconfig identifiers, restore the actual Helium macOS bundle IDs, and preserve those intentional identifiers in typos configuration.\n\nValidation:\n- nix develop --command prek run --all-files\n- nix flake check --no-build --all-systems