### PR TITLE
chore: move repository links to Nix Forge

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   enable:
     if: >-
-      github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'IanHollow/nix-conf' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false
+      github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'nix-forge/nix-conf' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   schedule:
     - cron: "17 3 * * 2"
   workflow_dispatch:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,6 +2,7 @@ name: Dependency Review
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  merge_group:
   workflow_dispatch:
 permissions: {}
 jobs:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "pkgs"]
 	path = pkgs
-	url = https://github.com/IanHollow/nixpkgs-personal.git
+	url = https://github.com/nix-forge/nixpkgs-personal.git
 	branch = main
 [submodule "nix-config-framework"]
 	path = nix-config-framework
-	url = https://github.com/IanHollow/nix-config-framework.git
+	url = https://github.com/nix-forge/nix-config-framework.git
 	branch = main
 [submodule "nix-seal"]
 	path = nix-seal
-	url = https://github.com/IanHollow/nix-seal.git
+	url = https://github.com/nix-forge/nix-seal.git


### PR DESCRIPTION
Update repository URLs, Dependabot ownership checks, and documentation references after transferring this repository to the Nix Forge organization.