### PR TITLE
security: add vulnerability reporting and ownership policy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Review ownership for the single-maintainer repository. Add independent
+# reviewers here as the maintainer team grows.
+* @IanHollow

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported versions
+
+The latest `main` branch and the currently supported NixOS unstable toolchain
+receive security fixes. Older revisions are not supported.
+
+## Reporting a vulnerability
+
+Do not open a public issue. Submit a report through
+[GitHub private vulnerability reporting](https://github.com/nix-forge/nix-conf/security/advisories/new).
+If that form is unavailable, contact the maintainer through the private address
+listed on the GitHub profile and request an encrypted channel.
+
+Please include the affected commit or version, the relevant host or module
+configuration, impact, and a minimal reproduction. Do not include live secrets
+or private identities in a report.
+
+We aim to acknowledge reports within 3 business days, provide an initial
+assessment within 7 business days, and agree coordinated disclosure timing with
+the reporter. Good-faith research that avoids privacy violations, persistence,
+destructive actions, and third-party systems is welcome.


### PR DESCRIPTION
## Summary

- Add linked private vulnerability-reporting policy and CODEOWNERS ownership.
- Keep Scorecard, CodeQL, merge-queue, dependency-review, and pinned-action controls in place.
- For `nix-seal`, enforce the documented upstream-unfixed RSA advisory exception with OSV-Scanner in the dev partition and CI.
- For `vpn-confinement`, force all site dependencies onto patched `esbuild 0.28.1` and refresh the Bun lockfile.

## Validation

- `prek run --all-files` passes in all five repositories.
- `nix flake check --no-build --all-systems` passes in all five repositories.
- `nix-seal` OSV-Scanner passes with the documented `RUSTSEC-2023-0071` exception.
- `vpn-confinement` Astro check/build passes with zero diagnostics.
- `bun audit --audit-level=high` reports no vulnerabilities.
