### PR TITLE
codex/private local service bootstrap rewritten

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           set -euo pipefail
           nix build --keep-going --show-trace --print-build-logs --no-link \
             ".#checks.${TARGET_SYSTEM}.treefmt" \
-            ".#checks.${TARGET_SYSTEM}.local-control-postgres-validation"
+            ".#checks.${TARGET_SYSTEM}.local-control-database-validation"
       - name: Build native Nix outputs
         id: native-build
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,8 @@ jobs:
         run: |
           set -euo pipefail
           nix build --keep-going --show-trace --print-build-logs --no-link \
-            ".#checks.${TARGET_SYSTEM}.treefmt"
+            ".#checks.${TARGET_SYSTEM}.treefmt" \
+            ".#checks.${TARGET_SYSTEM}.local-control-postgres-validation"
       - name: Build native Nix outputs
         id: native-build
         shell: bash

--- a/docs/local-control.md
+++ b/docs/local-control.md
@@ -1,34 +1,25 @@
-# Local control services and Windows development VM
+# Private local services
 
-This Home Manager configuration runs a private local application stack on macOS
-and provides host-only SSH access to a Windows development VM.
-
-## Local application stack
-
-`homes/macbook-pro-m4/local/local-control.nix` manages PostgreSQL, an API, a
-background worker, a dashboard development server, and an mTLS reverse proxy
-through launchd. The public configuration uses only generic service names.
-Project-specific paths, commands, database variable names, and credentials stay
-in a local owner-only environment file. Activate it with:
-
-```bash
-just home-switch ianmh@macbook-pro-m4
-```
+This module provides a small private local service set: a database,
+an API, a background worker, a web process, and an optional authenticated
+listener. Runtime values remain in an owner-only environment file; the public
+configuration contains only generic service logic and immutable tool identities.
 
 Runtime state is stored under `~/.local/state/local-control` with owner-only
-permissions. PostgreSQL, the browser API, and the dashboard bind to loopback.
-The reverse proxy binds only to the VMware host-only interface and requires a
-client certificate before forwarding requests.
+permissions. The environment file is
+`~/.local/state/local-control/environment`, outside this repository. A fresh
+activation creates the private state directories and any missing generated
+identity files safely. A missing environment file is allowed: guarded services
+remain stopped until the owner supplies it. Existing unsafe files, directories,
+or generated identities fail closed. Existing owner-owned regular service logs
+are safely tightened to mode `0600`; symlinks, foreign-owned files, and special
+files still fail closed.
 
-The private environment file is
-`~/.local/state/local-control/environment`; it is intentionally outside this
-repository. Activation does not create a placeholder file: if it is missing or
-empty, the launchd service guards exit successfully and remain stopped, so
-launchd does not repeatedly restart them. The file must be a regular,
-owner-readable file with no group or other permissions.
-
-It is a shell environment file and must provide these generic settings before
-the services can run:
+The service environment file is a strict line-oriented file. On the MacBook
+host it is `~/.local/state/local-control/service-environment`. Blank lines and lines
+beginning with `#` are ignored; every other line is one `NAME=VALUE` record.
+Values are not evaluated as shell syntax, duplicate names are rejected, carriage
+returns are rejected, and names outside this list are rejected:
 
 - `LOCAL_CONTROL_PROJECT_DIRECTORY`
 - `LOCAL_CONTROL_DATABASE_URL`
@@ -40,51 +31,27 @@ the services can run:
 - `LOCAL_CONTROL_PREPARE_COMMAND`
 - `LOCAL_CONTROL_PREPARATION_INPUT`
 - `LOCAL_CONTROL_READINESS_URL`
-- `SERVICE_PROXY_ATTESTATION`
 
-The database environment-variable name and every project-specific command are
-therefore private. Treat command settings as trusted owner-controlled shell
-commands. `LOCAL_CONTROL_PREPARATION_INPUT` is an owner-selected release or
-input identifier. Run `local-control-prepare` after changing the checkout,
-commands, or preparation input. It runs the locked dependency/setup command and
-writes an owner-only proof bound to the canonical checkout path, repository
-revision, tracked and untracked source inputs, preparation input, and setup
-command. The API, worker, and dashboard launch guards require that proof;
-launchd never installs dependencies at runtime.
+When the optional listener is enabled, `SERVICE_PROXY_ATTESTATION` is also
+required. It is rejected when that listener is disabled. Required settings must
+be non-empty. The database variable name must be a valid shell identifier.
 
-After preparation succeeds, use `local-control-restart` to ask launchd to start
-the guarded application services. The command skips the optional proxy when it
-is disabled.
+Run `local-control-prepare` after changing the checkout, commands, or
+preparation input. It runs the owner-selected preparation command and writes an
+owner-only proof. The proof binds the committed Git revision, a descriptor-bound
+snapshot of the complete source tree, the canonical environment snapshot, the
+preparation input, and the immutable runtime identities. Symlinks, special
+files, non-root checkouts, changing inputs, unsupported records, and unverifiable
+state fail closed. Raw setting values are not written to the proof.
 
-The PostgreSQL data directory is initialized only when it is empty and owned by
-the current user with mode `0700`. Existing directories are never chmodded into
-compliance: symlinks, non-owner directories, group/world access, missing
-control files, incompatible versions, and failed PostgreSQL control-data
-validation make activation stop without deleting or reinitializing data.
-Private keys remain under
-`~/.local/state/local-control/pki` and are not committed to this repository.
-Check the services with:
+The service guards require a current proof before starting. The database service
+is independently guarded because the other services wait for it. Its data and
+socket directories are checked by descriptor before a process is started, and a
+new data directory is initialized only when it is empty. The optional listener
+keeps its identity files descriptor-bound while starting. Generated files are
+created with exclusive or atomic operations; a pathname-only fallback is not
+used.
 
-```bash
-local-control-status
-```
-
-## Windows development VM
-
-`homes/macbook-pro-m4/local/dev-vm.nix` discovers a VMware host-only DHCP lease
-and exposes the VM through the `dev-vm` SSH alias. The VM may use NAT for
-outbound access, but administrative access stays on the host-only interface.
-
-Verify the host-only connection and common development tools with:
-
-```bash
-dev-vm-status
-```
-
-The SSH configuration deliberately creates no local port forwards. Keep Mac and
-Windows checkouts independent and exchange work through Git or Codex handoff
-rather than a shared writable source directory.
-
-Generated client identity files can be copied from the local PKI directory to a
-private directory on the VM when an application requires mTLS. Keep the private
-key readable only by the Windows user that runs the client.
+Use `local-control-restart` after preparation, and `local-control-status` to
+inspect readiness and listeners. These commands do not create dependencies or
+install packages at runtime.

--- a/docs/local-control.md
+++ b/docs/local-control.md
@@ -7,9 +7,9 @@ and provides host-only SSH access to a Windows development VM.
 
 `homes/macbook-pro-m4/local/local-control.nix` manages PostgreSQL, an API, a
 background worker, a dashboard development server, and an mTLS reverse proxy
-through launchd. The public configuration uses only generic service names and
-expects the private checkout to be available at
-`~/Developer/personal/workspace-service`. Activate it with:
+through launchd. The public configuration uses only generic service names.
+Project-specific paths, commands, database variable names, and credentials stay
+in a local owner-only environment file. Activate it with:
 
 ```bash
 just home-switch ianmh@macbook-pro-m4
@@ -22,9 +22,34 @@ client certificate before forwarding requests.
 
 The private environment file is
 `~/.local/state/local-control/environment`; it is intentionally outside this
-repository and must be created by the private application checkout before
-activation. Private keys remain under `~/.local/state/local-control/pki` and
-are not committed to this repository.
+repository. Activation creates an empty regular file with mode `0600` when it
+does not exist and refuses symlinks, non-owner files, or permissions available
+to group or others.
+
+It is a shell environment file and must provide these generic settings before
+the services can run:
+
+- `LOCAL_CONTROL_PROJECT_DIRECTORY`
+- `LOCAL_CONTROL_DATABASE_URL`
+- `LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE`
+- `LOCAL_CONTROL_SCHEMA_COMMAND`
+- `LOCAL_CONTROL_API_COMMAND`
+- `LOCAL_CONTROL_WORKER_COMMAND`
+- `LOCAL_CONTROL_FRONTEND_COMMAND`
+- `LOCAL_CONTROL_PREPARE_COMMAND`
+- `LOCAL_CONTROL_READINESS_URL`
+- `SERVICE_PROXY_ATTESTATION`
+
+The database environment-variable name and every project-specific command are
+therefore private. Treat command settings as trusted owner-controlled shell
+commands. Use `local-control-prepare` to perform any locked dependency setup
+before starting services; launchd deliberately does not install dependencies at
+runtime.
+
+The PostgreSQL data directory is initialized only when empty. If it contains
+files without a valid cluster marker, activation stops without modifying or
+removing them. Private keys remain under
+`~/.local/state/local-control/pki` and are not committed to this repository.
 Check the services with:
 
 ```bash

--- a/docs/local-control.md
+++ b/docs/local-control.md
@@ -22,9 +22,10 @@ client certificate before forwarding requests.
 
 The private environment file is
 `~/.local/state/local-control/environment`; it is intentionally outside this
-repository. Activation creates an empty regular file with mode `0600` when it
-does not exist and refuses symlinks, non-owner files, or permissions available
-to group or others.
+repository. Activation does not create a placeholder file: if it is missing or
+empty, the launchd service guards exit successfully and remain stopped, so
+launchd does not repeatedly restart them. The file must be a regular,
+owner-readable file with no group or other permissions.
 
 It is a shell environment file and must provide these generic settings before
 the services can run:
@@ -37,18 +38,30 @@ the services can run:
 - `LOCAL_CONTROL_WORKER_COMMAND`
 - `LOCAL_CONTROL_FRONTEND_COMMAND`
 - `LOCAL_CONTROL_PREPARE_COMMAND`
+- `LOCAL_CONTROL_PREPARATION_INPUT`
 - `LOCAL_CONTROL_READINESS_URL`
 - `SERVICE_PROXY_ATTESTATION`
 
 The database environment-variable name and every project-specific command are
 therefore private. Treat command settings as trusted owner-controlled shell
-commands. Use `local-control-prepare` to perform any locked dependency setup
-before starting services; launchd deliberately does not install dependencies at
-runtime.
+commands. `LOCAL_CONTROL_PREPARATION_INPUT` is an owner-selected release or
+input identifier. Run `local-control-prepare` after changing the checkout,
+commands, or preparation input. It runs the locked dependency/setup command and
+writes an owner-only proof bound to the canonical checkout path, repository
+revision, tracked and untracked source inputs, preparation input, and setup
+command. The API, worker, and dashboard launch guards require that proof;
+launchd never installs dependencies at runtime.
 
-The PostgreSQL data directory is initialized only when empty. If it contains
-files without a valid cluster marker, activation stops without modifying or
-removing them. Private keys remain under
+After preparation succeeds, use `local-control-restart` to ask launchd to start
+the guarded application services. The command skips the optional proxy when it
+is disabled.
+
+The PostgreSQL data directory is initialized only when it is empty and owned by
+the current user with mode `0700`. Existing directories are never chmodded into
+compliance: symlinks, non-owner directories, group/world access, missing
+control files, incompatible versions, and failed PostgreSQL control-data
+validation make activation stop without deleting or reinitializing data.
+Private keys remain under
 `~/.local/state/local-control/pki` and are not committed to this repository.
 Check the services with:
 

--- a/flake/dev/checks.nix
+++ b/flake/dev/checks.nix
@@ -1,0 +1,45 @@
+_: {
+  perSystem =
+    { pkgs, ... }:
+    let
+      postgresClusterValidator =
+        (import ../../lib/local-control/postgres-cluster-validator.nix { }).mkPostgresClusterValidator
+          pkgs;
+    in
+    {
+      checks.local-control-postgres-validation =
+        pkgs.runCommand "local-control-postgres-validation" { }
+          ''
+            set -euo pipefail
+
+            test_root="$TMPDIR/local-control-postgres-validation"
+            existing_cluster="$test_root/existing"
+            new_cluster="$test_root/new"
+            ${pkgs.coreutils}/bin/mkdir -p "$existing_cluster" "$new_cluster"
+
+            ${pkgs.postgresql_18}/bin/initdb \
+              --pgdata="$existing_cluster" \
+              --auth-local=trust \
+              --auth-host=scram-sha-256 \
+              --encoding=UTF8 \
+              --no-locale >/dev/null
+            ${pkgs.coreutils}/bin/env -i \
+              HOME="$TMPDIR" \
+              PATH=/no-such-path \
+              ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster "$existing_cluster"
+
+            ${pkgs.postgresql_18}/bin/initdb \
+              --pgdata="$new_cluster" \
+              --auth-local=trust \
+              --auth-host=scram-sha-256 \
+              --encoding=UTF8 \
+              --no-locale >/dev/null
+            ${pkgs.coreutils}/bin/env -i \
+              HOME="$TMPDIR" \
+              PATH=/no-such-path \
+              ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster "$new_cluster"
+
+            ${pkgs.coreutils}/bin/touch "$out"
+          '';
+    };
+}

--- a/flake/dev/checks.nix
+++ b/flake/dev/checks.nix
@@ -1,18 +1,23 @@
-_: {
+{ inputs, ... }: {
   perSystem =
     { pkgs, ... }:
     let
-      postgresClusterValidator =
-        (import ../../lib/local-control/postgres-cluster-validator.nix { }).mkPostgresClusterValidator
-          pkgs;
+      localControlLibrary = import ../../lib/local-control/postgres-cluster-validator.nix { };
+      secureFileSystem = localControlLibrary.mkSecureFileSystem pkgs;
+      environmentSnapshot = localControlLibrary.mkEnvironmentSnapshot pkgs;
+      sourceTreeSnapshot = localControlLibrary.mkSourceTreeSnapshot pkgs;
+      databaseClusterValidator = localControlLibrary.mkDatabaseClusterValidator pkgs;
+      preparationProof = localControlLibrary.mkPreparationProof pkgs;
+      preparationGate = localControlLibrary.mkPreparationGate pkgs;
+      privatePathGuard = localControlLibrary.mkPrivatePathGuard pkgs;
     in
     {
-      checks.local-control-postgres-validation =
-        pkgs.runCommand "local-control-postgres-validation" { }
+      checks.local-control-database-validation =
+        pkgs.runCommand "local-control-database-validation" { }
           ''
             set -euo pipefail
 
-            test_root="$TMPDIR/local-control-postgres-validation"
+            test_root="$TMPDIR/local-control-database-validation"
             existing_cluster="$test_root/existing"
             new_cluster="$test_root/new"
             ${pkgs.coreutils}/bin/mkdir -p "$existing_cluster" "$new_cluster"
@@ -26,18 +31,63 @@ _: {
             ${pkgs.coreutils}/bin/env -i \
               HOME="$TMPDIR" \
               PATH=/no-such-path \
-              ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster "$existing_cluster"
+              ${databaseClusterValidator}/bin/local-control-validate-database-cluster "$existing_cluster"
+
+            linked_cluster="$test_root/linked"
+            ${pkgs.coreutils}/bin/ln -s "$existing_cluster" "$linked_cluster"
+            if ${pkgs.coreutils}/bin/env -i \
+              HOME="$TMPDIR" \
+              PATH=/no-such-path \
+              ${databaseClusterValidator}/bin/local-control-validate-database-cluster "$linked_cluster"; then
+              printf 'A symlinked database directory was accepted.\n' >&2
+              exit 1
+            fi
+
+            ${pkgs.coreutils}/bin/chmod 755 "$existing_cluster"
+            if ${pkgs.coreutils}/bin/env -i \
+              HOME="$TMPDIR" \
+              PATH=/no-such-path \
+              ${databaseClusterValidator}/bin/local-control-validate-database-cluster "$existing_cluster"; then
+              printf 'A group-readable database directory was accepted.\n' >&2
+              exit 1
+            fi
+            ${pkgs.coreutils}/bin/chmod 700 "$existing_cluster"
+
+            ${pkgs.coreutils}/bin/chmod 644 "$existing_cluster/postgresql.conf"
+            if ${pkgs.coreutils}/bin/env -i \
+              HOME="$TMPDIR" \
+              PATH=/no-such-path \
+              ${databaseClusterValidator}/bin/local-control-validate-database-cluster "$existing_cluster"; then
+              printf 'A group-readable database control file was accepted.\n' >&2
+              exit 1
+            fi
+            ${pkgs.coreutils}/bin/chmod 600 "$existing_cluster/postgresql.conf"
+
+            corrupt_cluster="$test_root/corrupt"
+            ${pkgs.coreutils}/bin/mkdir -p "$corrupt_cluster"
+            ${pkgs.postgresql_18}/bin/initdb \
+              --pgdata="$corrupt_cluster" \
+              --auth-local=trust \
+              --auth-host=scram-sha-256 \
+              --encoding=UTF8 \
+              --no-locale >/dev/null
+            ${pkgs.coreutils}/bin/printf '17\n' > "$corrupt_cluster/PG_VERSION"
+            if ${pkgs.coreutils}/bin/env -i \
+              HOME="$TMPDIR" \
+              PATH=/no-such-path \
+              ${databaseClusterValidator}/bin/local-control-validate-database-cluster "$corrupt_cluster"; then
+              printf 'An incompatible database marker was accepted.\n' >&2
+              exit 1
+            fi
 
             if ${pkgs.coreutils}/bin/env -i \
               HOME="$TMPDIR" \
               PATH=/no-such-path \
-              ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster "$new_cluster"; then
-              printf 'An uninitialized PostgreSQL directory was accepted.\n' >&2
+              ${databaseClusterValidator}/bin/local-control-validate-database-cluster "$new_cluster"; then
+              printf 'An uninitialized database directory was accepted.\n' >&2
               exit 1
             fi
 
-            # Exercise the same post-initialization branch used by activation:
-            # an empty, private directory is initialized and then validated.
             ${pkgs.postgresql_18}/bin/initdb \
               --pgdata="$new_cluster" \
               --auth-local=trust \
@@ -47,8 +97,476 @@ _: {
             ${pkgs.coreutils}/bin/env -i \
               HOME="$TMPDIR" \
               PATH=/no-such-path \
-              ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster "$new_cluster"
+              ${databaseClusterValidator}/bin/local-control-validate-database-cluster "$new_cluster"
 
+            socket_directory="$test_root/socket"
+            postgres_log="$test_root/postgres.log"
+            ${pkgs.coreutils}/bin/mkdir -m 700 "$socket_directory"
+            postgres_pid=""
+            stop_postgres() {
+              if [ -n "$postgres_pid" ]; then
+                kill -TERM "$postgres_pid" 2>/dev/null || true
+                wait "$postgres_pid" 2>/dev/null || true
+              fi
+            }
+            trap stop_postgres EXIT
+            ${secureFileSystem}/bin/local-control-secure-files exec-cluster-socket \
+              "$new_cluster" \
+              18 \
+              "$socket_directory" \
+              ${pkgs.postgresql_18}/bin/postgres \
+              -D . \
+              -h "" \
+              -k @socket@ \
+              -p 55439 \
+              > "$postgres_log" 2>&1 &
+            postgres_pid=$!
+            postgres_ready=""
+            for attempt in $(${pkgs.coreutils}/bin/seq 1 60); do
+              if ${pkgs.postgresql_18}/bin/pg_isready \
+                -h "$socket_directory" \
+                -p 55439 >/dev/null 2>&1; then
+                postgres_ready=1
+                break
+              fi
+              ${pkgs.coreutils}/bin/sleep 1
+            done
+            if [ -z "$postgres_ready" ]; then
+              ${pkgs.coreutils}/bin/cat "$postgres_log" >&2
+              printf 'The descriptor-validated PostgreSQL socket path did not become ready.\n' >&2
+              exit 1
+            fi
+
+            ${pkgs.coreutils}/bin/touch "$out"
+          '';
+
+      checks.local-control-private-path-validation =
+        pkgs.runCommand "local-control-private-path-validation" { }
+          ''
+            set -euo pipefail
+
+            test_root="$TMPDIR/local-control-private-path-validation"
+            real_directory="$test_root/real"
+            target_directory="$test_root/target"
+            linked_directory="$test_root/linked"
+            bad_mode_directory="$test_root/bad-mode"
+            private_file="$test_root/private-file"
+            linked_file="$test_root/linked-file"
+            ${pkgs.coreutils}/bin/mkdir -p "$target_directory" "$bad_mode_directory"
+
+            ${privatePathGuard}/bin/local-control-private-path \
+              ensure-directory "$real_directory" "real directory"
+            [ "$(${pkgs.coreutils}/bin/stat -c '%a' "$real_directory")" = 700 ]
+
+            ${pkgs.coreutils}/bin/ln -s "$target_directory" "$linked_directory"
+            if ${privatePathGuard}/bin/local-control-private-path \
+              ensure-directory "$linked_directory" "linked directory" >/dev/null 2>&1; then
+              printf 'A directory symlink was accepted by the ensure guard.\n' >&2
+              exit 1
+            fi
+            if ${privatePathGuard}/bin/local-control-private-path \
+              validate-directory "$linked_directory" "linked directory" >/dev/null 2>&1; then
+              printf 'A directory symlink was accepted by the validation guard.\n' >&2
+              exit 1
+            fi
+
+            ${pkgs.coreutils}/bin/chmod 755 "$bad_mode_directory"
+            if ${privatePathGuard}/bin/local-control-private-path \
+              validate-directory "$bad_mode_directory" "bad mode directory" >/dev/null 2>&1; then
+              printf 'A group-readable directory was accepted.\n' >&2
+              exit 1
+            fi
+
+            ${pkgs.coreutils}/bin/printf 'private\n' > "$private_file"
+            ${pkgs.coreutils}/bin/chmod 600 "$private_file"
+            ${privatePathGuard}/bin/local-control-private-path \
+              validate-file "$private_file" "private file" 600
+            public_file="$test_root/public-file"
+            ${pkgs.coreutils}/bin/printf 'public\n' > "$public_file"
+            ${pkgs.coreutils}/bin/chmod 644 "$public_file"
+            ${privatePathGuard}/bin/local-control-private-path \
+              validate-file "$public_file" "public file" 644
+            ${pkgs.coreutils}/bin/ln -s "$private_file" "$linked_file"
+            if ${privatePathGuard}/bin/local-control-private-path \
+              validate-file "$linked_file" "linked file" 600 >/dev/null 2>&1; then
+              printf 'A file symlink was accepted.\n' >&2
+              exit 1
+            fi
+
+            ${pkgs.coreutils}/bin/touch "$out"
+          '';
+
+      checks.local-control-environment-validation =
+        pkgs.runCommand "local-control-environment-validation" { }
+          ''
+            set -euo pipefail
+
+            test_root="$TMPDIR/local-control-environment-validation"
+            environment_file="$test_root/environment"
+            ${pkgs.coreutils}/bin/mkdir -p "$test_root"
+
+            write_valid_environment() {
+              ${pkgs.coreutils}/bin/printf '%s\n' \
+                'LOCAL_CONTROL_PROJECT_DIRECTORY=/tmp/source' \
+                'LOCAL_CONTROL_DATABASE_URL=database-value' \
+                'LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE=LOCAL_CONTROL_DB_URL' \
+                'LOCAL_CONTROL_SCHEMA_COMMAND=schema command' \
+                'LOCAL_CONTROL_API_COMMAND=api command' \
+                'LOCAL_CONTROL_WORKER_COMMAND=worker command' \
+                'LOCAL_CONTROL_FRONTEND_COMMAND=frontend command' \
+                'LOCAL_CONTROL_PREPARE_COMMAND=prepare command' \
+                'LOCAL_CONTROL_PREPARATION_INPUT=input-a' \
+                'LOCAL_CONTROL_READINESS_URL=http://127.0.0.1/readiness' \
+                "''${1:+SERVICE_PROXY_ATTESTATION=attestation}" > "$environment_file"
+              ${pkgs.coreutils}/bin/chmod 600 "$environment_file"
+            }
+
+            assert_rejected() {
+              if ${environmentSnapshot}/bin/local-control-environment-snapshot read \
+                "$environment_file" "$1" >/dev/null 2>&1; then
+                printf 'Malformed environment input was accepted: %s\n' "$2" >&2
+                exit 1
+              fi
+            }
+
+            : > "$environment_file"
+            ${pkgs.coreutils}/bin/chmod 600 "$environment_file"
+            assert_rejected disabled empty
+
+            ${pkgs.coreutils}/bin/printf 'not a record\n' > "$environment_file"
+            assert_rejected disabled malformed
+
+            write_valid_environment
+            ${pkgs.coreutils}/bin/printf 'LOCAL_CONTROL_API_COMMAND=duplicate\n' >> "$environment_file"
+            assert_rejected disabled duplicate
+
+            write_valid_environment
+            ${pkgs.coreutils}/bin/printf 'UNSUPPORTED_SETTING=reject\n' >> "$environment_file"
+            assert_rejected disabled unsupported
+
+            ${pkgs.coreutils}/bin/printf 'LOCAL_CONTROL_PROJECT_DIRECTORY=/tmp/source\r\n' > "$environment_file"
+            assert_rejected disabled carriage-return
+
+            write_valid_environment
+            ${environmentSnapshot}/bin/local-control-environment-snapshot read \
+              "$environment_file" disabled >/dev/null
+            write_valid_environment enabled
+            ${environmentSnapshot}/bin/local-control-environment-snapshot read \
+              "$environment_file" enabled >/dev/null
+            write_valid_environment
+            ${pkgs.coreutils}/bin/mkfifo "$test_root/fifo"
+            if ${environmentSnapshot}/bin/local-control-environment-snapshot read \
+              "$test_root/fifo" disabled >/dev/null 2>&1; then
+              printf 'A FIFO environment input was accepted.\n' >&2
+              exit 1
+            fi
+            ${pkgs.coreutils}/bin/ln -s "$environment_file" "$test_root/linked"
+            if ${environmentSnapshot}/bin/local-control-environment-snapshot read \
+              "$test_root/linked" disabled >/dev/null 2>&1; then
+              printf 'A symlinked environment input was accepted.\n' >&2
+              exit 1
+            fi
+
+            race_source="$test_root/race-source"
+            ${pkgs.coreutils}/bin/mkdir -p "$race_source"
+            ${pkgs.coreutils}/bin/printf 'stable\n' > "$race_source/input"
+            ${pkgs.coreutils}/bin/chmod 600 "$race_source/input"
+            (
+              for race_iteration in $(${pkgs.coreutils}/bin/seq 1 100); do
+                ${pkgs.coreutils}/bin/printf 'stable\n' > "$race_source/input"
+                ${pkgs.coreutils}/bin/printf 'changed\n' > "$race_source/input"
+              done
+            ) &
+            race_writer=$!
+            while kill -0 "$race_writer" 2>/dev/null; do
+              race_read="$(${secureFileSystem}/bin/local-control-secure-files read-file \
+                "$race_source/input" 600 2>/dev/null || true)"
+              case "$race_read" in
+                ""|stable|changed)
+                  ;;
+                *)
+                  printf 'A raced file read produced an unstable result.\n' >&2
+                  exit 1
+                  ;;
+              esac
+            done
+            wait "$race_writer"
+            ${sourceTreeSnapshot}/bin/local-control-source-snapshot "$race_source" >/dev/null
+
+            ${pkgs.coreutils}/bin/touch "$out"
+          '';
+
+      checks.local-control-preparation-proof-validation =
+        pkgs.runCommand "local-control-preparation-proof-validation"
+          {
+            nativeBuildInputs = [
+              pkgs.coreutils
+              pkgs.git
+            ];
+          }
+          ''
+            set -euo pipefail
+
+            test_root="$TMPDIR/local-control-preparation-proof-validation"
+            project="$test_root/project"
+            environment_file="$test_root/environment"
+            ${pkgs.coreutils}/bin/mkdir -p "$project/empty-directory"
+            git -C "$project" init -q
+            git -C "$project" config user.email test@example.invalid
+            git -C "$project" config user.name test
+            ${pkgs.coreutils}/bin/printf 'ignored.txt\n' > "$project/.gitignore"
+            ${pkgs.coreutils}/bin/printf 'tracked-input\n' > "$project/source.txt"
+            git -C "$project" add .gitignore source.txt
+            git -C "$project" commit -qm initial
+            ${pkgs.coreutils}/bin/printf 'ignored-secret-content\n' > "$project/ignored.txt"
+            ${pkgs.coreutils}/bin/printf 'untracked-input\n' > "$project/untracked.txt"
+
+            status_output="$(git -C "$project" status --porcelain=v1 --ignored)"
+            case "$status_output" in
+              *'!! ignored.txt'*'?? untracked.txt'*|*'?? untracked.txt'*'!! ignored.txt'*)
+                ;;
+              *)
+                printf 'The ignored and untracked fixture inputs were not present at proof time.\n' >&2
+                exit 1
+                ;;
+            esac
+
+            write_environment() {
+              ${pkgs.coreutils}/bin/printf '%s\n' \
+                "LOCAL_CONTROL_PROJECT_DIRECTORY=$1" \
+                "LOCAL_CONTROL_DATABASE_URL=$2" \
+                'LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE=LOCAL_CONTROL_DB_URL' \
+                'LOCAL_CONTROL_SCHEMA_COMMAND=schema command' \
+                "LOCAL_CONTROL_API_COMMAND=$3" \
+                'LOCAL_CONTROL_WORKER_COMMAND=worker command' \
+                'LOCAL_CONTROL_FRONTEND_COMMAND=frontend command' \
+                'LOCAL_CONTROL_PREPARE_COMMAND=prepare command' \
+                'LOCAL_CONTROL_PREPARATION_INPUT=input-a' \
+                'LOCAL_CONTROL_READINESS_URL=http://127.0.0.1/readiness' \
+                "''${4:+SERVICE_PROXY_ATTESTATION=$4}" > "$environment_file"
+              ${pkgs.coreutils}/bin/chmod 600 "$environment_file"
+            }
+
+            proof_for() {
+              write_environment "$1" "$2" "$3" "''${4:-}"
+              ${pkgs.coreutils}/bin/env -i \
+                HOME="$TMPDIR" \
+                PATH=/no-such-path \
+                ${preparationProof}/bin/local-control-preparation-proof compute \
+                "$5" "$6" "$environment_file"
+            }
+
+            initial_proof="$(proof_for "$project" database-value 'api command' secret-attestation static-a enabled)"
+            [ "$(${pkgs.coreutils}/bin/printf '%s' "$initial_proof" | ${pkgs.coreutils}/bin/wc -c)" -eq 64 ]
+            case "$initial_proof" in
+              *[!0-9a-fA-F]*)
+                printf 'The preparation proof was not a hexadecimal digest.\n' >&2
+                exit 1
+                ;;
+            esac
+            case "$initial_proof" in
+              *secret-attestation*|*database-value*|*ignored-secret-content*)
+                printf 'A raw setting escaped into the preparation proof.\n' >&2
+                exit 1
+                ;;
+            esac
+
+            ${pkgs.coreutils}/bin/printf 'changed-ignored-content\n' > "$project/ignored.txt"
+            ignored_changed_proof="$(proof_for "$project" database-value 'api command' secret-attestation static-a enabled)"
+            [ "$initial_proof" != "$ignored_changed_proof" ]
+            ${pkgs.coreutils}/bin/printf 'changed-untracked-content\n' > "$project/untracked.txt"
+            untracked_changed_proof="$(proof_for "$project" database-value 'api command' secret-attestation static-a enabled)"
+            [ "$ignored_changed_proof" != "$untracked_changed_proof" ]
+            ${pkgs.coreutils}/bin/chmod 700 "$project/empty-directory"
+            mode_changed_proof="$(proof_for "$project" database-value 'api command' secret-attestation static-a enabled)"
+            [ "$untracked_changed_proof" != "$mode_changed_proof" ]
+            api_changed_proof="$(proof_for "$project" database-value 'changed api command' secret-attestation static-a enabled)"
+            [ "$mode_changed_proof" != "$api_changed_proof" ]
+
+            write_environment "$project" database-value 'api command' secret-attestation
+            ${pkgs.coreutils}/bin/printf 'UNSUPPORTED_SETTING=reject-me\n' >> "$environment_file"
+            if ${preparationProof}/bin/local-control-preparation-proof compute static-a enabled "$environment_file" >/dev/null 2>&1; then
+              printf 'An unsupported environment setting was accepted.\n' >&2
+              exit 1
+            fi
+
+            write_environment "$project" database-value 'api command' ""
+            disabled_proof="$(
+              ${pkgs.coreutils}/bin/env -i \
+                HOME="$TMPDIR" \
+                PATH=/no-such-path \
+                ${preparationProof}/bin/local-control-preparation-proof compute \
+                static-a disabled "$environment_file"
+            )"
+            [ "$(${pkgs.coreutils}/bin/printf '%s' "$disabled_proof" | ${pkgs.coreutils}/bin/wc -c)" -eq 64 ]
+
+            write_environment "$project" database-value 'api command' ""
+            ${pkgs.coreutils}/bin/printf 'SERVICE_PROXY_ATTESTATION=unexpected\n' >> "$environment_file"
+            if ${preparationProof}/bin/local-control-preparation-proof compute static-a disabled "$environment_file" >/dev/null 2>&1; then
+              printf 'A proxy setting was accepted while the proxy was disabled.\n' >&2
+              exit 1
+            fi
+
+            ${pkgs.coreutils}/bin/mkdir -p "$test_root/non-git"
+            ${pkgs.coreutils}/bin/printf 'source\n' > "$test_root/non-git/source.txt"
+            write_environment "$test_root/non-git" database-value 'api command' ""
+            if ${preparationProof}/bin/local-control-preparation-proof compute static-a disabled "$environment_file" >/dev/null 2>&1; then
+              printf 'A non-Git source tree was accepted.\n' >&2
+              exit 1
+            fi
+
+            ${pkgs.coreutils}/bin/mkdir -p "$project/linked-target"
+            ${pkgs.coreutils}/bin/ln -s linked-target "$project/linked-directory"
+            write_environment "$project" database-value 'api command' secret-attestation
+            if ${preparationProof}/bin/local-control-preparation-proof compute static-a enabled "$environment_file" >/dev/null 2>&1; then
+              printf 'A source symlink was accepted.\n' >&2
+              exit 1
+            fi
+
+            ${pkgs.coreutils}/bin/touch "$out"
+          '';
+
+      checks.local-control-preparation-gate-validation =
+        pkgs.runCommand "local-control-preparation-gate-validation"
+          {
+            nativeBuildInputs = [
+              pkgs.coreutils
+              pkgs.git
+            ];
+          }
+          ''
+            set -euo pipefail
+
+            test_root="$TMPDIR/local-control-preparation-gate-validation"
+            project="$test_root/project"
+            environment_file="$test_root/environment"
+            state_directory="$test_root/state"
+            preparation_stamp="$state_directory/preparation-stamp"
+            marker="$state_directory/marker"
+            ${pkgs.coreutils}/bin/mkdir -p "$project" "$state_directory"
+            ${pkgs.coreutils}/bin/chmod 700 "$state_directory"
+            git -C "$project" init -q
+            git -C "$project" config user.email test@example.invalid
+            git -C "$project" config user.name test
+            ${pkgs.coreutils}/bin/printf 'source\n' > "$project/source.txt"
+            git -C "$project" add source.txt
+            git -C "$project" commit -qm initial
+            ${pkgs.coreutils}/bin/printf '%s\n' \
+              "LOCAL_CONTROL_PROJECT_DIRECTORY=$project" \
+              'LOCAL_CONTROL_DATABASE_URL=database-value' \
+              'LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE=LOCAL_CONTROL_DB_URL' \
+              'LOCAL_CONTROL_SCHEMA_COMMAND=schema command' \
+              'LOCAL_CONTROL_API_COMMAND=api command' \
+              'LOCAL_CONTROL_WORKER_COMMAND=worker command' \
+              'LOCAL_CONTROL_FRONTEND_COMMAND=frontend command' \
+              'LOCAL_CONTROL_PREPARE_COMMAND=prepare command' \
+              'LOCAL_CONTROL_PREPARATION_INPUT=input-a' \
+              'LOCAL_CONTROL_READINESS_URL=http://127.0.0.1/readiness' \
+              'SERVICE_PROXY_ATTESTATION=attestation' > "$environment_file"
+            ${pkgs.coreutils}/bin/chmod 600 "$environment_file"
+
+            run_gate() {
+              GATE_MARKER="$marker" \
+                ${preparationGate}/bin/local-control-service-gate \
+                "$environment_file" "$preparation_stamp" "$state_directory" \
+                static-gate enabled \
+                ${pkgs.bash}/bin/bash -c 'printf ran > "$GATE_MARKER"'
+            }
+
+            run_gate
+            [ ! -f "$marker" ]
+
+            state="$(${preparationProof}/bin/local-control-preparation-proof compute \
+              static-gate enabled "$environment_file")"
+            ${pkgs.coreutils}/bin/printf '%s\n' stale > "$preparation_stamp"
+            ${pkgs.coreutils}/bin/chmod 600 "$preparation_stamp"
+            run_gate
+            [ ! -f "$marker" ]
+
+            ${pkgs.coreutils}/bin/printf '%s\n' "$state" > "$preparation_stamp"
+            ${pkgs.coreutils}/bin/chmod 600 "$preparation_stamp"
+            run_gate
+            [ -f "$marker" ]
+
+            ${pkgs.coreutils}/bin/printf '%s\n' \
+              "LOCAL_CONTROL_PROJECT_DIRECTORY=$project" \
+              'LOCAL_CONTROL_DATABASE_URL=database-value' \
+              'LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE=LOCAL_CONTROL_DB_URL' \
+              'LOCAL_CONTROL_SCHEMA_COMMAND=schema command' \
+              'LOCAL_CONTROL_API_COMMAND=api command' \
+              'LOCAL_CONTROL_WORKER_COMMAND=worker command' \
+              'LOCAL_CONTROL_FRONTEND_COMMAND=frontend command' \
+              'LOCAL_CONTROL_PREPARE_COMMAND=prepare command' \
+              'LOCAL_CONTROL_PREPARATION_INPUT=input-a' \
+              'LOCAL_CONTROL_READINESS_URL=http://127.0.0.1/readiness' > "$environment_file"
+            ${pkgs.coreutils}/bin/chmod 600 "$environment_file"
+            disabled_state="$(${preparationProof}/bin/local-control-preparation-proof compute \
+              static-gate disabled "$environment_file")"
+            disabled_stamp="$state_directory/disabled-stamp"
+            ${pkgs.coreutils}/bin/printf '%s\n' "$disabled_state" > "$disabled_stamp"
+            ${pkgs.coreutils}/bin/chmod 600 "$disabled_stamp"
+            disabled_marker="$state_directory/disabled-marker"
+            GATE_MARKER="$disabled_marker" \
+              ${preparationGate}/bin/local-control-service-gate \
+              "$environment_file" "$disabled_stamp" "$state_directory" \
+              static-gate disabled \
+              ${pkgs.bash}/bin/bash -c 'printf ran > "$GATE_MARKER"'
+            [ -f "$disabled_marker" ]
+
+            ${pkgs.coreutils}/bin/touch "$out"
+          '';
+      checks.local-control-generated-activation =
+        let
+          activationHome = "/private/tmp/local-control-activation-${builtins.hashString "sha256" (builtins.readFile ../../homes/macbook-pro-m4/local/local-control.nix)}";
+          homeConfiguration = inputs.home-manager.lib.homeManagerConfiguration {
+            inherit pkgs;
+            modules = [
+              ../../homes/macbook-pro-m4/local/local-control.nix
+              {
+                home.username = "check-user";
+                home.homeDirectory = activationHome;
+                home.stateVersion = "24.11";
+                services.localControl.enable = true;
+              }
+            ];
+          };
+          activationScript = pkgs.writeText "local-control-generated-activation-script" homeConfiguration.config.home.activation.localControlState.data;
+        in
+        pkgs.runCommand "local-control-generated-activation"
+          {
+            nativeBuildInputs = [
+              pkgs.bash
+              pkgs.coreutils
+              pkgs.gnused
+            ];
+          }
+          ''
+            set -euo pipefail
+            activation_runtime_home="$TMPDIR/local-control-activation-home"
+            activation_runtime_script="$TMPDIR/local-control-activation-script"
+            ${pkgs.gnused}/bin/sed \
+              "s|${activationHome}|$activation_runtime_home|g" \
+              ${activationScript} > "$activation_runtime_script"
+            ${pkgs.bash}/bin/bash -n "$activation_runtime_script"
+            ${pkgs.bash}/bin/bash "$activation_runtime_script"
+
+            ${pkgs.coreutils}/bin/touch "$activation_runtime_home/.local/state/local-control/logs/api.out.log"
+            ${pkgs.coreutils}/bin/chmod 644 "$activation_runtime_home/.local/state/local-control/logs/api.out.log"
+            ${pkgs.bash}/bin/bash "$activation_runtime_script"
+            [ "$(${pkgs.coreutils}/bin/stat -c '%a' "$activation_runtime_home/.local/state/local-control/logs/api.out.log")" = 600 ]
+
+            ${pkgs.bash}/bin/bash "$activation_runtime_script"
+
+            activation_state="$activation_runtime_home/.local/state/local-control"
+            [ -d "$activation_state" ]
+            [ -f "$activation_state/database/PG_VERSION" ]
+            [ -f "$activation_state/pki/ca.crt" ]
+            [ -f "$activation_state/pki/ca.key" ]
+            [ -f "$activation_state/pki/server.crt" ]
+            [ -f "$activation_state/pki/server.key" ]
+            [ -f "$activation_state/pki/client.crt" ]
+            [ -f "$activation_state/pki/client.key" ]
+            [ ! -e "$activation_state/service-environment" ]
             ${pkgs.coreutils}/bin/touch "$out"
           '';
     };

--- a/flake/dev/checks.nix
+++ b/flake/dev/checks.nix
@@ -28,6 +28,16 @@ _: {
               PATH=/no-such-path \
               ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster "$existing_cluster"
 
+            if ${pkgs.coreutils}/bin/env -i \
+              HOME="$TMPDIR" \
+              PATH=/no-such-path \
+              ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster "$new_cluster"; then
+              printf 'An uninitialized PostgreSQL directory was accepted.\n' >&2
+              exit 1
+            fi
+
+            # Exercise the same post-initialization branch used by activation:
+            # an empty, private directory is initialized and then validated.
             ${pkgs.postgresql_18}/bin/initdb \
               --pgdata="$new_cluster" \
               --auth-local=trust \

--- a/flake/dev/default.nix
+++ b/flake/dev/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./checks.nix
     ./formatter.nix
     ./git-hooks.nix
     ./shell.nix

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -39,6 +39,26 @@
         "type": "github"
       }
     },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786031233,
+        "narHash": "sha256-TIDlLTLI1/pB7IqgjzcKQjpODQsZE2oII4XGG9B6KjI=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "7834e82588860aaf780cec1366524456a70898d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1785692966,
@@ -59,6 +79,7 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "git-hooks-nix": "git-hooks-nix",
+        "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -2,6 +2,11 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     git-hooks-nix = {
       url = "github:cachix/git-hooks.nix";
       inputs = {

--- a/homes/macbook-pro-m4/default.nix
+++ b/homes/macbook-pro-m4/default.nix
@@ -88,9 +88,10 @@ in
       };
     })
     server-ssh
-    (_: {
+    ({ config, ... }: {
       services.localControl = {
         enable = true;
+        environmentFile = "${config.xdg.stateHome}/local-control/service-environment";
       };
       # Retain the host-only VM diagnostics and SSH helpers that accompany the
       # control host.

--- a/homes/macbook-pro-m4/local/local-control.nix
+++ b/homes/macbook-pro-m4/local/local-control.nix
@@ -83,7 +83,7 @@ let
       done
       cd ${lib.escapeShellArg cfg.projectDirectory}
       uv run --locked alembic -c database/alembic.ini upgrade head
-      exec uv run --locked prop-control-api
+      exec uv run --locked workspace-api
     '';
   };
 
@@ -104,7 +104,7 @@ let
       export MKL_NUM_THREADS=1
       export VECLIB_MAXIMUM_THREADS=1
       cd ${lib.escapeShellArg cfg.projectDirectory}
-      exec uv run --locked prop-calculation-worker
+      exec uv run --locked workspace-worker
     '';
   };
 

--- a/homes/macbook-pro-m4/local/local-control.nix
+++ b/homes/macbook-pro-m4/local/local-control.nix
@@ -14,6 +14,21 @@ let
   pkiDir = "${stateDir}/pki";
   inherit (cfg) environmentFile;
   logDir = "${stateDir}/logs";
+  preparationStamp = "${stateDir}/preparation-stamp";
+
+  privateServiceSettings = [
+    "LOCAL_CONTROL_PROJECT_DIRECTORY"
+    "LOCAL_CONTROL_DATABASE_URL"
+    "LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE"
+    "LOCAL_CONTROL_SCHEMA_COMMAND"
+    "LOCAL_CONTROL_API_COMMAND"
+    "LOCAL_CONTROL_WORKER_COMMAND"
+    "LOCAL_CONTROL_FRONTEND_COMMAND"
+    "LOCAL_CONTROL_PREPARE_COMMAND"
+    "LOCAL_CONTROL_PREPARATION_INPUT"
+    "LOCAL_CONTROL_READINESS_URL"
+    "SERVICE_PROXY_ATTESTATION"
+  ];
 
   requirePrivateSettings =
     names:
@@ -21,6 +36,14 @@ let
       if [ -z "''${${name}:-}" ]; then
         printf 'Missing required private service setting: ${name}\n' >&2
         exit 78
+      fi
+    '') names;
+
+  checkPrivateSettings =
+    names:
+    lib.concatMapStringsSep "\n" (name: ''
+      if [ -z "''${${name}:-}" ]; then
+        return 1
       fi
     '') names;
 
@@ -49,26 +72,126 @@ let
     set +a
   '';
 
+  validateDatabaseEnvironment = ''
+    validate_database_environment() {
+      case "''${LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE:-}" in
+        [A-Za-z_]* )
+          case "$LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE" in
+            *[!A-Za-z0-9_]* )
+              return 1
+              ;;
+          esac
+          ;;
+        * )
+          return 1
+          ;;
+      esac
+    }
+  '';
+
   prepareDatabaseEnvironment = ''
     ${requirePrivateSettings [
       "LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE"
       "LOCAL_CONTROL_DATABASE_URL"
     ]}
-    case "$LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE" in
-      [A-Za-z_]* )
-        case "$LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE" in
-          *[!A-Za-z0-9_]* )
-            printf 'The configured database environment variable name is invalid.\n' >&2
-            exit 64
-            ;;
-        esac
-        ;;
-      * )
-        printf 'The configured database environment variable name is invalid.\n' >&2
-        exit 64
-        ;;
-    esac
+    ${validateDatabaseEnvironment}
+    if ! validate_database_environment; then
+      printf 'The configured database environment variable name is invalid.\n' >&2
+      exit 64
+    fi
     export "$LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE=$LOCAL_CONTROL_DATABASE_URL"
+  '';
+
+  computePreparationState = ''
+    compute_preparation_state() {
+      preparation_project_directory="$(cd "$LOCAL_CONTROL_PROJECT_DIRECTORY" 2>/dev/null && pwd -P)" || return 1
+      [ -d "$preparation_project_directory" ] || return 1
+
+      preparation_revision="unversioned"
+      preparation_files_digest="unversioned"
+      if git -C "$preparation_project_directory" rev-parse --show-toplevel >/dev/null 2>&1; then
+        preparation_revision="$(git -C "$preparation_project_directory" rev-parse --verify HEAD 2>/dev/null)" || return 1
+        preparation_files_digest="$(
+          git -C "$preparation_project_directory" ls-files -co --exclude-standard -z |
+            while IFS= read -r -d "" preparation_file; do
+              preparation_path="$preparation_project_directory/$preparation_file"
+              if [ -f "$preparation_path" ] && [ ! -L "$preparation_path" ]; then
+                printf '%s\0' "$preparation_file"
+                sha256sum "$preparation_path"
+              fi
+            done |
+            sha256sum |
+            cut -d ' ' -f 1
+        )" || return 1
+      fi
+
+      preparation_command_digest="$(printf '%s' "$LOCAL_CONTROL_PREPARE_COMMAND" | sha256sum | cut -d ' ' -f 1)" || return 1
+      preparation_state="$(
+        printf '%s\0%s\0%s\0%s\0%s' \
+          "$preparation_project_directory" \
+          "$LOCAL_CONTROL_PREPARATION_INPUT" \
+          "$preparation_revision" \
+          "$preparation_files_digest" \
+          "$preparation_command_digest" |
+          sha256sum |
+          cut -d ' ' -f 1
+      )" || return 1
+    }
+  '';
+
+  checkPreparationStamp = ''
+    preparation_stamp_matches() {
+      if [ -L ${lib.escapeShellArg preparationStamp} ] || [ ! -f ${lib.escapeShellArg preparationStamp} ]; then
+        return 1
+      fi
+      if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg preparationStamp} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
+        return 1
+      fi
+      preparation_stamp_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg preparationStamp} )"
+      if (( (8#$preparation_stamp_mode & 0077) != 0 )); then
+        return 1
+      fi
+      if [ "$(wc -l < ${lib.escapeShellArg preparationStamp} | tr -d ' ')" != 1 ]; then
+        return 1
+      fi
+      [ "$(tr -d '\n' < ${lib.escapeShellArg preparationStamp})" = "$preparation_state" ]
+    }
+  '';
+
+  requirePreparation = ''
+    ${requirePrivateSettings [
+      "LOCAL_CONTROL_PROJECT_DIRECTORY"
+      "LOCAL_CONTROL_PREPARE_COMMAND"
+      "LOCAL_CONTROL_PREPARATION_INPUT"
+    ]}
+    ${computePreparationState}
+    ${checkPreparationStamp}
+    if ! compute_preparation_state || ! preparation_stamp_matches; then
+      printf 'Local services require a successful owner-run local-control-prepare for the current checkout and inputs.\n' >&2
+      exit 78
+    fi
+  '';
+
+  privateEnvironmentReady = ''
+    private_environment_ready() {
+      if [ ! -f ${lib.escapeShellArg environmentFile} ] || [ -L ${lib.escapeShellArg environmentFile} ]; then
+        return 1
+      fi
+      if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg environmentFile} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
+        return 1
+      fi
+      private_environment_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg environmentFile} )"
+      if (( (8#$private_environment_mode & 0077) != 0 )); then
+        return 1
+      fi
+      set -a
+      # shellcheck disable=SC1091
+      . ${lib.escapeShellArg environmentFile}
+      set +a
+      ${checkPrivateSettings privateServiceSettings}
+      ${validateDatabaseEnvironment}
+      validate_database_environment || return 1
+    }
   '';
 
   waitForDatabase = ''
@@ -84,6 +207,79 @@ let
       ${pkgs.coreutils}/bin/sleep 1
     done
   '';
+
+  validatePostgresCluster = ''
+    validate_postgres_cluster() {
+      postgres_data_dir="$1"
+      if [ -L "$postgres_data_dir" ] || [ ! -d "$postgres_data_dir" ]; then
+        return 1
+      fi
+      if [ "$( stat -c '%u' "$postgres_data_dir" )" != "$( id -u )" ]; then
+        return 1
+      fi
+      postgres_dir_mode="$( stat -c '%a' "$postgres_data_dir" )"
+      if (( (8#$postgres_dir_mode & 0077) != 0 )); then
+        return 1
+      fi
+      for postgres_control_file in PG_VERSION postgresql.conf pg_hba.conf pg_ident.conf; do
+        postgres_control_path="$postgres_data_dir/$postgres_control_file"
+        if [ -L "$postgres_control_path" ] || [ ! -f "$postgres_control_path" ]; then
+          return 1
+        fi
+        if [ "$( stat -c '%u' "$postgres_control_path" )" != "$( id -u )" ]; then
+          return 1
+        fi
+        postgres_control_mode="$( stat -c '%a' "$postgres_control_path" )"
+        if (( (8#$postgres_control_mode & 0077) != 0 )); then
+          return 1
+        fi
+      done
+      for postgres_control_dir in base global pg_wal; do
+        postgres_control_path="$postgres_data_dir/$postgres_control_dir"
+        if [ -L "$postgres_control_path" ] || [ ! -d "$postgres_control_path" ]; then
+          return 1
+        fi
+        if [ "$( stat -c '%u' "$postgres_control_path" )" != "$( id -u )" ]; then
+          return 1
+        fi
+        postgres_control_mode="$( stat -c '%a' "$postgres_control_path" )"
+        if (( (8#$postgres_control_mode & 0077) != 0 )); then
+          return 1
+        fi
+      done
+      postgres_major=""
+      IFS= read -r postgres_major < "$postgres_data_dir/PG_VERSION" || true
+      [ "$postgres_major" = 18 ] || return 1
+      pg_controldata "$postgres_data_dir" >/dev/null 2>&1
+    }
+  '';
+
+  serviceGate = pkgs.writeShellApplication {
+    name = "local-control-service-gate";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.git
+    ];
+    text = ''
+      set -eu
+      if [ "$#" -lt 1 ]; then
+        printf 'A service command is required.\n' >&2
+        exit 64
+      fi
+      ${privateEnvironmentReady}
+      if ! private_environment_ready; then
+        printf 'Private service environment or preparation proof is not ready; run local-control-prepare after configuring it.\n' >&2
+        exit 0
+      fi
+      ${computePreparationState}
+      ${checkPreparationStamp}
+      if ! compute_preparation_state || ! preparation_stamp_matches; then
+        printf 'Local service preparation is stale; run local-control-prepare before starting services.\n' >&2
+        exit 0
+      fi
+      exec "$@"
+    '';
+  };
 
   runPrivateCommand = setting: ''
     ${requirePrivateSettings [ setting ]}
@@ -124,18 +320,16 @@ let
 
   postgres = pkgs.writeShellApplication {
     name = "local-control-postgres";
-    runtimeInputs = [ pkgs.postgresql_18 ];
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.postgresql_18
+    ];
     text = ''
       set -eu
-      if [ ! -s ${lib.escapeShellArg "${postgresDir}/PG_VERSION"} ]; then
-        printf 'Local PostgreSQL data directory is not initialized; run Home Manager activation first.\n' >&2
-        exit 78
-      fi
-      postgres_major=""
-      IFS= read -r postgres_major < ${lib.escapeShellArg "${postgresDir}/PG_VERSION"} || true
-      if [ "$postgres_major" != 18 ]; then
-        printf 'Local PostgreSQL data directory has an incompatible major version.\n' >&2
-        exit 78
+      ${validatePostgresCluster}
+      if ! validate_postgres_cluster ${lib.escapeShellArg postgresDir}; then
+        printf 'Local PostgreSQL data directory is incomplete, unsafe, or corrupt.\n' >&2
+        exit 0
       fi
       mkdir -p ${lib.escapeShellArg postgresSocketDir}
       chmod 700 ${lib.escapeShellArg postgresSocketDir}
@@ -152,12 +346,15 @@ let
     runtimeInputs = [
       pkgs.postgresql_18
       pkgs.uv
+      pkgs.coreutils
+      pkgs.git
     ];
     text = ''
       set -eu
       ${loadPrivateEnvironment}
       ${prepareDatabaseEnvironment}
       ${requirePrivateSettings [ "LOCAL_CONTROL_PROJECT_DIRECTORY" ]}
+      ${requirePreparation}
       ${waitForDatabase}
       cd "$LOCAL_CONTROL_PROJECT_DIRECTORY"
       ${runPrivateCommand "LOCAL_CONTROL_SCHEMA_COMMAND"}
@@ -170,12 +367,15 @@ let
     runtimeInputs = [
       pkgs.postgresql_18
       pkgs.uv
+      pkgs.coreutils
+      pkgs.git
     ];
     text = ''
       set -eu
       ${loadPrivateEnvironment}
       ${prepareDatabaseEnvironment}
       ${requirePrivateSettings [ "LOCAL_CONTROL_PROJECT_DIRECTORY" ]}
+      ${requirePreparation}
       ${waitForDatabase}
       export OMP_NUM_THREADS=1
       export OPENBLAS_NUM_THREADS=1
@@ -191,11 +391,14 @@ let
     runtimeInputs = [
       pkgs.nodejs_24
       pkgs.pnpm
+      pkgs.coreutils
+      pkgs.git
     ];
     text = ''
       set -eu
       ${loadPrivateEnvironment}
       ${requirePrivateSettings [ "LOCAL_CONTROL_PROJECT_DIRECTORY" ]}
+      ${requirePreparation}
       cd "$LOCAL_CONTROL_PROJECT_DIRECTORY"
       ${execPrivateCommand "LOCAL_CONTROL_FRONTEND_COMMAND"}
     '';
@@ -207,20 +410,39 @@ let
       pkgs.nodejs_24
       pkgs.pnpm
       pkgs.uv
+      pkgs.coreutils
+      pkgs.git
     ];
     text = ''
       set -eu
       ${loadPrivateEnvironment}
       ${prepareDatabaseEnvironment}
-      ${requirePrivateSettings [ "LOCAL_CONTROL_PROJECT_DIRECTORY" ]}
+      ${requirePrivateSettings [
+        "LOCAL_CONTROL_PROJECT_DIRECTORY"
+        "LOCAL_CONTROL_PREPARE_COMMAND"
+        "LOCAL_CONTROL_PREPARATION_INPUT"
+      ]}
       cd "$LOCAL_CONTROL_PROJECT_DIRECTORY"
       ${runPrivateCommand "LOCAL_CONTROL_PREPARE_COMMAND"}
+      umask 077
+      if [ -L ${lib.escapeShellArg preparationStamp} ] || [ -e ${lib.escapeShellArg preparationStamp} ] && [ ! -f ${lib.escapeShellArg preparationStamp} ]; then
+        printf 'Preparation proof path must be a regular file.\n' >&2
+        exit 1
+      fi
+      ${computePreparationState}
+      preparation_stamp_tmp="$(mktemp ${lib.escapeShellArg "${preparationStamp}.XXXXXX"})"
+      printf '%s\n' "$preparation_state" > "$preparation_stamp_tmp"
+      chmod 600 "$preparation_stamp_tmp"
+      mv -f "$preparation_stamp_tmp" ${lib.escapeShellArg preparationStamp}
     '';
   };
 
   caddy = pkgs.writeShellApplication {
     name = "local-control-caddy";
-    runtimeInputs = [ pkgs.caddy ];
+    runtimeInputs = [
+      pkgs.caddy
+      pkgs.coreutils
+    ];
     text = ''
       set -eu
       ${loadPrivateEnvironment}
@@ -232,6 +454,7 @@ let
   status = pkgs.writeShellApplication {
     name = "local-control-status";
     runtimeInputs = [
+      pkgs.coreutils
       pkgs.curl
       pkgs.postgresql_18
       pkgs.lsof
@@ -259,8 +482,12 @@ let
     text = ''
       set -eu
       domain="gui/$(id -u)"
-      launchctl kickstart -k "$domain/dev.ianmh.local-control-worker"
-      launchctl kickstart -k "$domain/dev.ianmh.local-control-api"
+      for service in worker api frontend caddy; do
+        label="$domain/dev.ianmh.local-control-$service"
+        if launchctl print "$label" >/dev/null 2>&1; then
+          launchctl kickstart -k "$label"
+        fi
+      done
     '';
   };
 in
@@ -340,33 +567,64 @@ in
     home.activation.localControlState = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       set -eu
       umask 0077
-      mkdir -p \
-        ${lib.escapeShellArg stateDir} \
-        ${lib.escapeShellArg postgresDir} \
-        ${lib.escapeShellArg postgresSocketDir} \
-        ${lib.escapeShellArg pkiDir} \
-        ${lib.escapeShellArg logDir}
-      chmod 700 \
-        ${lib.escapeShellArg stateDir} \
-        ${lib.escapeShellArg postgresDir} \
-        ${lib.escapeShellArg postgresSocketDir} \
-        ${lib.escapeShellArg pkiDir} \
-        ${lib.escapeShellArg logDir}
-
-      postgres_version_file=${lib.escapeShellArg "${postgresDir}/PG_VERSION"}
-      if [ -e "$postgres_version_file" ] || [ -L "$postgres_version_file" ]; then
-        if [ ! -f "$postgres_version_file" ] || [ -L "$postgres_version_file" ] || [ ! -s "$postgres_version_file" ]; then
-          printf 'Refusing to use an invalid local PostgreSQL data directory.\n' >&2
+      state_dir_preexisting=false
+      if [ -L ${lib.escapeShellArg stateDir} ] || [ -e ${lib.escapeShellArg stateDir} ] && [ ! -d ${lib.escapeShellArg stateDir} ]; then
+        printf 'Local service state directory must be a real directory.\n' >&2
+        exit 1
+      fi
+      if [ -d ${lib.escapeShellArg stateDir} ]; then
+        state_dir_preexisting=true
+      fi
+      mkdir -p ${lib.escapeShellArg stateDir}
+      if [ "$state_dir_preexisting" = true ]; then
+        if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg stateDir} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
+          printf 'Local service state directory must be owned by the current user.\n' >&2
           exit 1
         fi
-        postgres_major=""
-        IFS= read -r postgres_major < "$postgres_version_file" || true
-        if [ "$postgres_major" != 18 ]; then
-          printf 'Refusing to use a local PostgreSQL data directory with an incompatible major version.\n' >&2
+        state_dir_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg stateDir} )"
+        if (( (8#$state_dir_mode & 0077) != 0 )); then
+          printf 'Local service state directory must not be accessible to group or others.\n' >&2
+          exit 1
+        fi
+      fi
+      chmod 700 ${lib.escapeShellArg stateDir}
+
+      postgres_dir_preexisting=false
+      if [ -L ${lib.escapeShellArg postgresDir} ] || [ -e ${lib.escapeShellArg postgresDir} ] && [ ! -d ${lib.escapeShellArg postgresDir} ]; then
+        printf 'Refusing a symlinked or non-directory PostgreSQL data path.\n' >&2
+        exit 1
+      fi
+      if [ -d ${lib.escapeShellArg postgresDir} ]; then
+        postgres_dir_preexisting=true
+      else
+        mkdir ${lib.escapeShellArg postgresDir}
+      fi
+      if [ "$postgres_dir_preexisting" = true ]; then
+        if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg postgresDir} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
+          printf 'Refusing a PostgreSQL data directory not owned by the current user.\n' >&2
+          exit 1
+        fi
+        postgres_dir_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg postgresDir} )"
+        if (( (8#$postgres_dir_mode & 0077) != 0 )); then
+          printf 'Refusing a PostgreSQL data directory accessible to group or others.\n' >&2
+          exit 1
+        fi
+      fi
+      chmod 700 ${lib.escapeShellArg postgresDir}
+
+      postgres_version_file=${lib.escapeShellArg "${postgresDir}/PG_VERSION"}
+      if [ -L "$postgres_version_file" ] || [ -e "$postgres_version_file" ] && [ ! -f "$postgres_version_file" ]; then
+        printf 'Refusing an invalid PostgreSQL cluster marker.\n' >&2
+        exit 1
+      fi
+      if [ -f "$postgres_version_file" ]; then
+        ${validatePostgresCluster}
+        if ! validate_postgres_cluster ${lib.escapeShellArg postgresDir}; then
+          printf 'Refusing an incomplete, unsafe, or corrupt PostgreSQL data directory.\n' >&2
           exit 1
         fi
       elif [ -n "$( ${pkgs.findutils}/bin/find ${lib.escapeShellArg postgresDir} -mindepth 1 -maxdepth 1 -print -quit )" ]; then
-        printf 'Refusing to initialize a non-empty local PostgreSQL data directory.\n' >&2
+        printf 'Refusing to initialize a non-empty PostgreSQL data directory without a valid cluster marker.\n' >&2
         exit 1
       else
         ${pkgs.postgresql_18}/bin/initdb \
@@ -375,6 +633,11 @@ in
           --auth-host=scram-sha-256 \
           --encoding=UTF8 \
           --no-locale
+        ${validatePostgresCluster}
+        if ! validate_postgres_cluster ${lib.escapeShellArg postgresDir}; then
+          printf 'PostgreSQL initialization did not produce a valid cluster.\n' >&2
+          exit 1
+        fi
       fi
 
       if [ -e ${lib.escapeShellArg environmentFile} ] || [ -L ${lib.escapeShellArg environmentFile} ]; then
@@ -382,10 +645,27 @@ in
           printf 'Private service environment must be a regular file.\n' >&2
           exit 1
         fi
+        if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg environmentFile} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
+          printf 'Private service environment must be owned by the current user.\n' >&2
+          exit 1
+        fi
+        environment_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg environmentFile} )"
+        if (( (8#$environment_mode & 0077) != 0 )); then
+          printf 'Private service environment must not be readable by group or others.\n' >&2
+          exit 1
+        fi
       else
-        : > ${lib.escapeShellArg environmentFile}
+        printf 'Private service environment is not configured; services remain gated until it is created by the owner.\n' >&2
       fi
-      chmod 600 ${lib.escapeShellArg environmentFile}
+
+      mkdir -p \
+        ${lib.escapeShellArg postgresSocketDir} \
+        ${lib.escapeShellArg pkiDir} \
+        ${lib.escapeShellArg logDir}
+      chmod 700 \
+        ${lib.escapeShellArg postgresSocketDir} \
+        ${lib.escapeShellArg pkiDir} \
+        ${lib.escapeShellArg logDir}
 
       if [ ! -f ${lib.escapeShellArg "${pkiDir}/ca.crt"} ]; then
         ${pkgs.openssl}/bin/openssl req -x509 -new -nodes -sha256 -days 3650 \
@@ -461,7 +741,9 @@ in
         Label = "dev.ianmh.local-control-postgres";
         ProgramArguments = [ "${postgres}/bin/local-control-postgres" ];
         RunAtLoad = true;
-        KeepAlive = true;
+        KeepAlive = {
+          SuccessfulExit = false;
+        };
         ThrottleInterval = 10;
         ProcessType = "Background";
         StandardOutPath = "${logDir}/postgres.out.log";
@@ -473,9 +755,14 @@ in
       enable = true;
       config = {
         Label = "dev.ianmh.local-control-api";
-        ProgramArguments = [ "${api}/bin/local-control-api" ];
+        ProgramArguments = [
+          "${serviceGate}/bin/local-control-service-gate"
+          "${api}/bin/local-control-api"
+        ];
         RunAtLoad = true;
-        KeepAlive = true;
+        KeepAlive = {
+          SuccessfulExit = false;
+        };
         ThrottleInterval = 10;
         ProcessType = "Background";
         StandardOutPath = "${logDir}/api.out.log";
@@ -487,9 +774,14 @@ in
       enable = true;
       config = {
         Label = "dev.ianmh.local-control-worker";
-        ProgramArguments = [ "${worker}/bin/local-control-worker" ];
+        ProgramArguments = [
+          "${serviceGate}/bin/local-control-service-gate"
+          "${worker}/bin/local-control-worker"
+        ];
         RunAtLoad = true;
-        KeepAlive = true;
+        KeepAlive = {
+          SuccessfulExit = false;
+        };
         ThrottleInterval = 10;
         ProcessType = "Interactive";
         StandardOutPath = "${logDir}/worker.out.log";
@@ -501,9 +793,14 @@ in
       enable = true;
       config = {
         Label = "dev.ianmh.local-control-frontend";
-        ProgramArguments = [ "${frontend}/bin/local-control-frontend" ];
+        ProgramArguments = [
+          "${serviceGate}/bin/local-control-service-gate"
+          "${frontend}/bin/local-control-frontend"
+        ];
         RunAtLoad = true;
-        KeepAlive = true;
+        KeepAlive = {
+          SuccessfulExit = false;
+        };
         ThrottleInterval = 10;
         ProcessType = "Background";
         StandardOutPath = "${logDir}/frontend.out.log";
@@ -515,9 +812,14 @@ in
       enable = true;
       config = {
         Label = "dev.ianmh.local-control-caddy";
-        ProgramArguments = [ "${caddy}/bin/local-control-caddy" ];
+        ProgramArguments = [
+          "${serviceGate}/bin/local-control-service-gate"
+          "${caddy}/bin/local-control-caddy"
+        ];
         RunAtLoad = true;
-        KeepAlive = true;
+        KeepAlive = {
+          SuccessfulExit = false;
+        };
         ThrottleInterval = 10;
         ProcessType = "Background";
         StandardOutPath = "${logDir}/caddy.out.log";

--- a/homes/macbook-pro-m4/local/local-control.nix
+++ b/homes/macbook-pro-m4/local/local-control.nix
@@ -208,51 +208,9 @@ let
     done
   '';
 
-  validatePostgresCluster = ''
-    validate_postgres_cluster() {
-      postgres_data_dir="$1"
-      if [ -L "$postgres_data_dir" ] || [ ! -d "$postgres_data_dir" ]; then
-        return 1
-      fi
-      if [ "$( stat -c '%u' "$postgres_data_dir" )" != "$( id -u )" ]; then
-        return 1
-      fi
-      postgres_dir_mode="$( stat -c '%a' "$postgres_data_dir" )"
-      if (( (8#$postgres_dir_mode & 0077) != 0 )); then
-        return 1
-      fi
-      for postgres_control_file in PG_VERSION postgresql.conf pg_hba.conf pg_ident.conf; do
-        postgres_control_path="$postgres_data_dir/$postgres_control_file"
-        if [ -L "$postgres_control_path" ] || [ ! -f "$postgres_control_path" ]; then
-          return 1
-        fi
-        if [ "$( stat -c '%u' "$postgres_control_path" )" != "$( id -u )" ]; then
-          return 1
-        fi
-        postgres_control_mode="$( stat -c '%a' "$postgres_control_path" )"
-        if (( (8#$postgres_control_mode & 0077) != 0 )); then
-          return 1
-        fi
-      done
-      for postgres_control_dir in base global pg_wal; do
-        postgres_control_path="$postgres_data_dir/$postgres_control_dir"
-        if [ -L "$postgres_control_path" ] || [ ! -d "$postgres_control_path" ]; then
-          return 1
-        fi
-        if [ "$( stat -c '%u' "$postgres_control_path" )" != "$( id -u )" ]; then
-          return 1
-        fi
-        postgres_control_mode="$( stat -c '%a' "$postgres_control_path" )"
-        if (( (8#$postgres_control_mode & 0077) != 0 )); then
-          return 1
-        fi
-      done
-      postgres_major=""
-      IFS= read -r postgres_major < "$postgres_data_dir/PG_VERSION" || true
-      [ "$postgres_major" = 18 ] || return 1
-      pg_controldata "$postgres_data_dir" >/dev/null 2>&1
-    }
-  '';
+  postgresClusterValidator =
+    (import ../../../lib/local-control/postgres-cluster-validator.nix { }).mkPostgresClusterValidator
+      pkgs;
 
   serviceGate = pkgs.writeShellApplication {
     name = "local-control-service-gate";
@@ -326,8 +284,7 @@ let
     ];
     text = ''
       set -eu
-      ${validatePostgresCluster}
-      if ! validate_postgres_cluster ${lib.escapeShellArg postgresDir}; then
+      if ! ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster ${lib.escapeShellArg postgresDir}; then
         printf 'Local PostgreSQL data directory is incomplete, unsafe, or corrupt.\n' >&2
         exit 0
       fi
@@ -618,8 +575,7 @@ in
         exit 1
       fi
       if [ -f "$postgres_version_file" ]; then
-        ${validatePostgresCluster}
-        if ! validate_postgres_cluster ${lib.escapeShellArg postgresDir}; then
+        if ! ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster ${lib.escapeShellArg postgresDir}; then
           printf 'Refusing an incomplete, unsafe, or corrupt PostgreSQL data directory.\n' >&2
           exit 1
         fi
@@ -633,8 +589,7 @@ in
           --auth-host=scram-sha-256 \
           --encoding=UTF8 \
           --no-locale
-        ${validatePostgresCluster}
-        if ! validate_postgres_cluster ${lib.escapeShellArg postgresDir}; then
+        if ! ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster ${lib.escapeShellArg postgresDir}; then
           printf 'PostgreSQL initialization did not produce a valid cluster.\n' >&2
           exit 1
         fi

--- a/homes/macbook-pro-m4/local/local-control.nix
+++ b/homes/macbook-pro-m4/local/local-control.nix
@@ -15,16 +15,84 @@ let
   inherit (cfg) environmentFile;
   logDir = "${stateDir}/logs";
 
-  loadEnvironment = ''
+  requirePrivateSettings =
+    names:
+    lib.concatMapStringsSep "\n" (name: ''
+      if [ -z "''${${name}:-}" ]; then
+        printf 'Missing required private service setting: ${name}\n' >&2
+        exit 78
+      fi
+    '') names;
+
+  loadPrivateEnvironment = ''
     set -eu
-    if [ ! -r ${lib.escapeShellArg environmentFile} ]; then
+    if [ ! -f ${lib.escapeShellArg environmentFile} ] || [ -L ${lib.escapeShellArg environmentFile} ]; then
       printf 'Missing private service environment: %s\n' ${lib.escapeShellArg environmentFile} >&2
+      exit 78
+    fi
+    if [ ! -r ${lib.escapeShellArg environmentFile} ]; then
+      printf 'Private service environment is not readable.\n' >&2
+      exit 78
+    fi
+    if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg environmentFile} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
+      printf 'Private service environment must be owned by the current user.\n' >&2
+      exit 78
+    fi
+    environment_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg environmentFile} )"
+    if (( (8#$environment_mode & 0077) != 0 )); then
+      printf 'Private service environment must not be readable by group or others.\n' >&2
       exit 78
     fi
     set -a
     # shellcheck disable=SC1091
     . ${lib.escapeShellArg environmentFile}
     set +a
+  '';
+
+  prepareDatabaseEnvironment = ''
+    ${requirePrivateSettings [
+      "LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE"
+      "LOCAL_CONTROL_DATABASE_URL"
+    ]}
+    case "$LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE" in
+      [A-Za-z_]* )
+        case "$LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE" in
+          *[!A-Za-z0-9_]* )
+            printf 'The configured database environment variable name is invalid.\n' >&2
+            exit 64
+            ;;
+        esac
+        ;;
+      * )
+        printf 'The configured database environment variable name is invalid.\n' >&2
+        exit 64
+        ;;
+    esac
+    export "$LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE=$LOCAL_CONTROL_DATABASE_URL"
+  '';
+
+  waitForDatabase = ''
+    attempt=0
+    until ${pkgs.postgresql_18}/bin/pg_isready \
+      -h 127.0.0.1 \
+      -p ${toString cfg.postgresPort} >/dev/null 2>&1; do
+      attempt=$((attempt + 1))
+      if [ "$attempt" -ge 60 ]; then
+        printf 'Timed out waiting for local PostgreSQL readiness.\n' >&2
+        exit 75
+      fi
+      ${pkgs.coreutils}/bin/sleep 1
+    done
+  '';
+
+  runPrivateCommand = setting: ''
+    ${requirePrivateSettings [ setting ]}
+    ${pkgs.bash}/bin/bash -o errexit -o pipefail -c "''${${setting}}"
+  '';
+
+  execPrivateCommand = setting: ''
+    ${requirePrivateSettings [ setting ]}
+    exec ${pkgs.bash}/bin/bash -o errexit -o pipefail -c "''${${setting}}"
   '';
 
   caddyConfig = pkgs.writeText "local-control.Caddyfile" ''
@@ -59,6 +127,16 @@ let
     runtimeInputs = [ pkgs.postgresql_18 ];
     text = ''
       set -eu
+      if [ ! -s ${lib.escapeShellArg "${postgresDir}/PG_VERSION"} ]; then
+        printf 'Local PostgreSQL data directory is not initialized; run Home Manager activation first.\n' >&2
+        exit 78
+      fi
+      postgres_major=""
+      IFS= read -r postgres_major < ${lib.escapeShellArg "${postgresDir}/PG_VERSION"} || true
+      if [ "$postgres_major" != 18 ]; then
+        printf 'Local PostgreSQL data directory has an incompatible major version.\n' >&2
+        exit 78
+      fi
       mkdir -p ${lib.escapeShellArg postgresSocketDir}
       chmod 700 ${lib.escapeShellArg postgresSocketDir}
       exec postgres \
@@ -77,13 +155,13 @@ let
     ];
     text = ''
       set -eu
-      ${loadEnvironment}
-      until pg_isready -h 127.0.0.1 -p ${toString cfg.postgresPort}; do
-        sleep 1
-      done
-      cd ${lib.escapeShellArg cfg.projectDirectory}
-      uv run --locked alembic -c database/alembic.ini upgrade head
-      exec uv run --locked workspace-api
+      ${loadPrivateEnvironment}
+      ${prepareDatabaseEnvironment}
+      ${requirePrivateSettings [ "LOCAL_CONTROL_PROJECT_DIRECTORY" ]}
+      ${waitForDatabase}
+      cd "$LOCAL_CONTROL_PROJECT_DIRECTORY"
+      ${runPrivateCommand "LOCAL_CONTROL_SCHEMA_COMMAND"}
+      ${execPrivateCommand "LOCAL_CONTROL_API_COMMAND"}
     '';
   };
 
@@ -95,16 +173,16 @@ let
     ];
     text = ''
       set -eu
-      ${loadEnvironment}
-      until pg_isready -h 127.0.0.1 -p ${toString cfg.postgresPort}; do
-        sleep 1
-      done
+      ${loadPrivateEnvironment}
+      ${prepareDatabaseEnvironment}
+      ${requirePrivateSettings [ "LOCAL_CONTROL_PROJECT_DIRECTORY" ]}
+      ${waitForDatabase}
       export OMP_NUM_THREADS=1
       export OPENBLAS_NUM_THREADS=1
       export MKL_NUM_THREADS=1
       export VECLIB_MAXIMUM_THREADS=1
-      cd ${lib.escapeShellArg cfg.projectDirectory}
-      exec uv run --locked workspace-worker
+      cd "$LOCAL_CONTROL_PROJECT_DIRECTORY"
+      ${execPrivateCommand "LOCAL_CONTROL_WORKER_COMMAND"}
     '';
   };
 
@@ -116,11 +194,27 @@ let
     ];
     text = ''
       set -eu
-      cd ${lib.escapeShellArg cfg.projectDirectory}
-      if [ ! -d apps/dashboard/node_modules/.pnpm ]; then
-        pnpm --dir apps/dashboard install --frozen-lockfile
-      fi
-      exec pnpm --dir apps/dashboard dev --host 127.0.0.1 --port ${toString cfg.frontendPort}
+      ${loadPrivateEnvironment}
+      ${requirePrivateSettings [ "LOCAL_CONTROL_PROJECT_DIRECTORY" ]}
+      cd "$LOCAL_CONTROL_PROJECT_DIRECTORY"
+      ${execPrivateCommand "LOCAL_CONTROL_FRONTEND_COMMAND"}
+    '';
+  };
+
+  prepare = pkgs.writeShellApplication {
+    name = "local-control-prepare";
+    runtimeInputs = [
+      pkgs.nodejs_24
+      pkgs.pnpm
+      pkgs.uv
+    ];
+    text = ''
+      set -eu
+      ${loadPrivateEnvironment}
+      ${prepareDatabaseEnvironment}
+      ${requirePrivateSettings [ "LOCAL_CONTROL_PROJECT_DIRECTORY" ]}
+      cd "$LOCAL_CONTROL_PROJECT_DIRECTORY"
+      ${runPrivateCommand "LOCAL_CONTROL_PREPARE_COMMAND"}
     '';
   };
 
@@ -129,7 +223,8 @@ let
     runtimeInputs = [ pkgs.caddy ];
     text = ''
       set -eu
-      ${loadEnvironment}
+      ${loadPrivateEnvironment}
+      ${requirePrivateSettings [ "SERVICE_PROXY_ATTESTATION" ]}
       exec caddy run --config ${lib.escapeShellArg caddyConfig} --adapter caddyfile
     '';
   };
@@ -143,11 +238,13 @@ let
     ];
     text = ''
       set -eu
-      ${loadEnvironment}
+      ${loadPrivateEnvironment}
+      ${prepareDatabaseEnvironment}
+      ${requirePrivateSettings [ "LOCAL_CONTROL_READINESS_URL" ]}
       printf 'PostgreSQL: '
       pg_isready -h 127.0.0.1 -p ${toString cfg.postgresPort}
-      printf '\nControl API: '
-      curl --fail --silent http://127.0.0.1:${toString cfg.apiPort}/api/health/ready
+      printf '\nApplication: '
+      curl --fail --silent --show-error "$LOCAL_CONTROL_READINESS_URL"
       printf '\n\nListeners:\n'
       lsof -nP \
         -iTCP:${toString cfg.frontendPort} \
@@ -170,12 +267,6 @@ in
 {
   options.services.localControl = {
     enable = lib.mkEnableOption "private local application stack";
-
-    projectDirectory = lib.mkOption {
-      type = lib.types.path;
-      default = "/Users/ianmh/Developer/personal/workspace-service";
-      description = "Checked-out application repository used by the local services.";
-    };
 
     environmentFile = lib.mkOption {
       type = lib.types.path;
@@ -222,9 +313,26 @@ in
         assertion = isDarwin;
         message = "services.localControl is implemented for the local macOS control host.";
       }
+      {
+        assertion = !(lib.hasPrefix "${builtins.storeDir}/" (toString cfg.environmentFile));
+        message = "services.localControl.environmentFile must remain outside the Nix store.";
+      }
+      {
+        assertion =
+          builtins.length (
+            lib.unique [
+              cfg.frontendPort
+              cfg.apiPort
+              cfg.agentPort
+              cfg.postgresPort
+            ]
+          ) == 4;
+        message = "services.localControl requires distinct frontend, API, agent, and PostgreSQL ports.";
+      }
     ];
 
     home.packages = [
+      prepare
       restart
       status
     ];
@@ -234,14 +342,50 @@ in
       umask 0077
       mkdir -p \
         ${lib.escapeShellArg stateDir} \
+        ${lib.escapeShellArg postgresDir} \
         ${lib.escapeShellArg postgresSocketDir} \
         ${lib.escapeShellArg pkiDir} \
         ${lib.escapeShellArg logDir}
       chmod 700 \
         ${lib.escapeShellArg stateDir} \
+        ${lib.escapeShellArg postgresDir} \
         ${lib.escapeShellArg postgresSocketDir} \
         ${lib.escapeShellArg pkiDir} \
         ${lib.escapeShellArg logDir}
+
+      postgres_version_file=${lib.escapeShellArg "${postgresDir}/PG_VERSION"}
+      if [ -e "$postgres_version_file" ] || [ -L "$postgres_version_file" ]; then
+        if [ ! -f "$postgres_version_file" ] || [ -L "$postgres_version_file" ] || [ ! -s "$postgres_version_file" ]; then
+          printf 'Refusing to use an invalid local PostgreSQL data directory.\n' >&2
+          exit 1
+        fi
+        postgres_major=""
+        IFS= read -r postgres_major < "$postgres_version_file" || true
+        if [ "$postgres_major" != 18 ]; then
+          printf 'Refusing to use a local PostgreSQL data directory with an incompatible major version.\n' >&2
+          exit 1
+        fi
+      elif [ -n "$( ${pkgs.findutils}/bin/find ${lib.escapeShellArg postgresDir} -mindepth 1 -maxdepth 1 -print -quit )" ]; then
+        printf 'Refusing to initialize a non-empty local PostgreSQL data directory.\n' >&2
+        exit 1
+      else
+        ${pkgs.postgresql_18}/bin/initdb \
+          --pgdata=${lib.escapeShellArg postgresDir} \
+          --auth-local=trust \
+          --auth-host=scram-sha-256 \
+          --encoding=UTF8 \
+          --no-locale
+      fi
+
+      if [ -e ${lib.escapeShellArg environmentFile} ] || [ -L ${lib.escapeShellArg environmentFile} ]; then
+        if [ -L ${lib.escapeShellArg environmentFile} ] || [ ! -f ${lib.escapeShellArg environmentFile} ]; then
+          printf 'Private service environment must be a regular file.\n' >&2
+          exit 1
+        fi
+      else
+        : > ${lib.escapeShellArg environmentFile}
+      fi
+      chmod 600 ${lib.escapeShellArg environmentFile}
 
       if [ ! -f ${lib.escapeShellArg "${pkiDir}/ca.crt"} ]; then
         ${pkgs.openssl}/bin/openssl req -x509 -new -nodes -sha256 -days 3650 \

--- a/homes/macbook-pro-m4/local/local-control.nix
+++ b/homes/macbook-pro-m4/local/local-control.nix
@@ -9,8 +9,8 @@ let
 
   cfg = config.services.localControl;
   stateDir = "${config.xdg.stateHome}/local-control";
-  postgresDir = "${stateDir}/postgres";
-  postgresSocketDir = "${stateDir}/postgres-socket";
+  databaseDir = "${stateDir}/database";
+  databaseSocketDir = "${stateDir}/database-socket";
   pkiDir = "${stateDir}/pki";
   inherit (cfg) environmentFile;
   logDir = "${stateDir}/logs";
@@ -27,8 +27,66 @@ let
     "LOCAL_CONTROL_PREPARE_COMMAND"
     "LOCAL_CONTROL_PREPARATION_INPUT"
     "LOCAL_CONTROL_READINESS_URL"
-    "SERVICE_PROXY_ATTESTATION"
-  ];
+  ]
+  ++ lib.optionals cfg.proxyEnable [ "SERVICE_PROXY_ATTESTATION" ];
+
+  localControlLibrary = import ../../../lib/local-control/postgres-cluster-validator.nix { };
+  preparationProof = localControlLibrary.mkPreparationProof pkgs;
+  privatePathGuard = localControlLibrary.mkPrivatePathGuard pkgs;
+  secureFileSystem = localControlLibrary.mkSecureFileSystem pkgs;
+  environmentSnapshot = localControlLibrary.mkEnvironmentSnapshot pkgs;
+  sourceTreeSnapshot = localControlLibrary.mkSourceTreeSnapshot pkgs;
+
+  launchConfigurationDigest = builtins.hashString "sha256" (
+    builtins.toJSON {
+      moduleSource = builtins.hashString "sha256" (builtins.readFile ./local-control.nix);
+      safetyLibrarySource = builtins.hashString "sha256" (
+        builtins.readFile ../../../lib/local-control/postgres-cluster-validator.nix
+      );
+      secureFileSystemSource = builtins.hashString "sha256" (
+        builtins.readFile ../../../lib/local-control/secure-files.c
+      );
+      environmentFile = toString environmentFile;
+      stateDirectory = stateDir;
+      databaseDirectory = databaseDir;
+      databaseSocketDirectory = databaseSocketDir;
+      pkiDirectory = pkiDir;
+      logDirectory = logDir;
+      inherit preparationStamp;
+      environmentSnapshot = "${environmentSnapshot}/bin/local-control-environment-snapshot";
+      sourceTreeSnapshot = "${sourceTreeSnapshot}/bin/local-control-source-snapshot";
+      runtimeStorePathIdentities = {
+        bash = "${pkgs.bash}/bin/bash";
+        proxy = "${pkgs.caddy}/bin/caddy";
+        coreutils = "${pkgs.coreutils}/bin";
+        curl = "${pkgs.curl}/bin/curl";
+        git = "${pkgs.git}/bin/git";
+        lsof = "${pkgs.lsof}/bin/lsof";
+        node = "${pkgs.nodejs_24}/bin/node";
+        openssl = "${pkgs.openssl}/bin/openssl";
+        packageManager = "${pkgs.pnpm}/bin/pnpm";
+        database = "${pkgs.postgresql_18}/bin/postgres";
+        databaseControlData = "${pkgs.postgresql_18}/bin/pg_controldata";
+        databaseReadiness = "${pkgs.postgresql_18}/bin/pg_isready";
+        pythonRunner = "${pkgs.uv}/bin/uv";
+        secureFileSystem = "${secureFileSystem}/bin/local-control-secure-files";
+        validator = "${databaseClusterValidator}/bin/local-control-validate-database-cluster";
+        pathGuard = "${privatePathGuard}/bin/local-control-private-path";
+        proof = "${preparationProof}/bin/local-control-preparation-proof";
+        serviceGate = "${serviceGate}/bin/local-control-service-gate";
+        databaseLauncher = "${database}/bin/local-control-database";
+        proxyLauncher = "${proxy}/bin/local-control-proxy";
+        proxyConfiguration = toString proxyConfig;
+        initdb = "${pkgs.postgresql_18}/bin/initdb";
+      };
+      inherit (cfg) bindAddress;
+      inherit (cfg) webPort;
+      inherit (cfg) apiPort;
+      inherit (cfg) proxyPort;
+      inherit (cfg) databasePort;
+      inherit (cfg) proxyEnable;
+    }
+  );
 
   requirePrivateSettings =
     names:
@@ -48,28 +106,75 @@ let
     '') names;
 
   loadPrivateEnvironment = ''
-    set -eu
-    if [ ! -f ${lib.escapeShellArg environmentFile} ] || [ -L ${lib.escapeShellArg environmentFile} ]; then
-      printf 'Missing private service environment: %s\n' ${lib.escapeShellArg environmentFile} >&2
+    load_private_environment() {
+      set -eu
+      if [ -n "''${LOCAL_CONTROL_ENVIRONMENT_SNAPSHOT:-}" ]; then
+        environment_source="$LOCAL_CONTROL_ENVIRONMENT_SNAPSHOT"
+      else
+        environment_source=${lib.escapeShellArg (toString environmentFile)}
+      fi
+      environment_snapshot="$(${pkgs.coreutils}/bin/mktemp ${lib.escapeShellArg "${stateDir}/environment-snapshot.XXXXXX"})" || return 1
+      if ! ${environmentSnapshot}/bin/local-control-environment-snapshot read \
+        "$environment_source" \
+        ${
+          lib.escapeShellArg (if cfg.proxyEnable then "enabled" else "disabled")
+        } > "$environment_snapshot"; then
+        ${pkgs.coreutils}/bin/rm -f "$environment_snapshot"
+        return 1
+      fi
+      environment_seen='|'
+      for environment_name in ${lib.concatStringsSep " " privateServiceSettings}; do
+        unset "$environment_name"
+      done
+      while IFS= read -r environment_line || [ -n "$environment_line" ]; do
+        case "$environment_line" in
+          ""|\#*)
+            continue
+            ;;
+          *=*)
+            environment_name="''${environment_line%%=*}"
+            environment_value="''${environment_line#*=}"
+            ;;
+          *)
+            printf 'The environment snapshot is not a NAME=VALUE file.\n' >&2
+            return 1
+            ;;
+        esac
+        case "$environment_name" in
+          ${lib.concatStringsSep "|" privateServiceSettings})
+            ;;
+          *)
+            printf 'The environment snapshot contains an unsupported setting.\n' >&2
+            return 1
+            ;;
+        esac
+        case "$environment_seen" in
+          *"|$environment_name|"*)
+            printf 'The environment snapshot contains a duplicate setting.\n' >&2
+            return 1
+            ;;
+        esac
+        environment_seen="''${environment_seen}''${environment_name}|"
+        export "$environment_name=$environment_value"
+      done < "$environment_snapshot"
+      ${checkPrivateSettings privateServiceSettings}
+      ${validateDatabaseEnvironment}
+      validate_database_environment || return 1
+    }
+    load_private_environment || {
+      printf 'The service environment is missing, unsafe, or invalid.\n' >&2
       exit 78
-    fi
-    if [ ! -r ${lib.escapeShellArg environmentFile} ]; then
-      printf 'Private service environment is not readable.\n' >&2
-      exit 78
-    fi
-    if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg environmentFile} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
-      printf 'Private service environment must be owned by the current user.\n' >&2
-      exit 78
-    fi
-    environment_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg environmentFile} )"
-    if (( (8#$environment_mode & 0077) != 0 )); then
-      printf 'Private service environment must not be readable by group or others.\n' >&2
-      exit 78
-    fi
-    set -a
-    # shellcheck disable=SC1091
-    . ${lib.escapeShellArg environmentFile}
-    set +a
+    }
+  '';
+
+  cleanupPrivateEnvironment = ''
+    cleanup_private_environment() {
+      if [ -n "''${environment_snapshot:-}" ]; then
+        ${pkgs.coreutils}/bin/rm -f "$environment_snapshot"
+        unset environment_snapshot
+      fi
+      unset LOCAL_CONTROL_ENVIRONMENT_SNAPSHOT
+    }
   '';
 
   validateDatabaseEnvironment = ''
@@ -104,57 +209,18 @@ let
 
   computePreparationState = ''
     compute_preparation_state() {
-      preparation_project_directory="$(cd "$LOCAL_CONTROL_PROJECT_DIRECTORY" 2>/dev/null && pwd -P)" || return 1
-      [ -d "$preparation_project_directory" ] || return 1
-
-      preparation_revision="unversioned"
-      preparation_files_digest="unversioned"
-      if git -C "$preparation_project_directory" rev-parse --show-toplevel >/dev/null 2>&1; then
-        preparation_revision="$(git -C "$preparation_project_directory" rev-parse --verify HEAD 2>/dev/null)" || return 1
-        preparation_files_digest="$(
-          git -C "$preparation_project_directory" ls-files -co --exclude-standard -z |
-            while IFS= read -r -d "" preparation_file; do
-              preparation_path="$preparation_project_directory/$preparation_file"
-              if [ -f "$preparation_path" ] && [ ! -L "$preparation_path" ]; then
-                printf '%s\0' "$preparation_file"
-                sha256sum "$preparation_path"
-              fi
-            done |
-            sha256sum |
-            cut -d ' ' -f 1
-        )" || return 1
-      fi
-
-      preparation_command_digest="$(printf '%s' "$LOCAL_CONTROL_PREPARE_COMMAND" | sha256sum | cut -d ' ' -f 1)" || return 1
-      preparation_state="$(
-        printf '%s\0%s\0%s\0%s\0%s' \
-          "$preparation_project_directory" \
-          "$LOCAL_CONTROL_PREPARATION_INPUT" \
-          "$preparation_revision" \
-          "$preparation_files_digest" \
-          "$preparation_command_digest" |
-          sha256sum |
-          cut -d ' ' -f 1
-      )" || return 1
+      preparation_state="$(${preparationProof}/bin/local-control-preparation-proof compute \
+        ${lib.escapeShellArg launchConfigurationDigest} \
+        ${lib.escapeShellArg (if cfg.proxyEnable then "enabled" else "disabled")} \
+        "$environment_snapshot")" || return 1
     }
   '';
 
   checkPreparationStamp = ''
     preparation_stamp_matches() {
-      if [ -L ${lib.escapeShellArg preparationStamp} ] || [ ! -f ${lib.escapeShellArg preparationStamp} ]; then
-        return 1
-      fi
-      if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg preparationStamp} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
-        return 1
-      fi
-      preparation_stamp_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg preparationStamp} )"
-      if (( (8#$preparation_stamp_mode & 0077) != 0 )); then
-        return 1
-      fi
-      if [ "$(wc -l < ${lib.escapeShellArg preparationStamp} | tr -d ' ')" != 1 ]; then
-        return 1
-      fi
-      [ "$(tr -d '\n' < ${lib.escapeShellArg preparationStamp})" = "$preparation_state" ]
+      preparation_stamp_value="$(${secureFileSystem}/bin/local-control-secure-files read-file \
+        ${lib.escapeShellArg preparationStamp} 600)" || return 1
+      [ "$preparation_stamp_value" = "$preparation_state" ]
     }
   '';
 
@@ -172,84 +238,49 @@ let
     fi
   '';
 
-  privateEnvironmentReady = ''
-    private_environment_ready() {
-      if [ ! -f ${lib.escapeShellArg environmentFile} ] || [ -L ${lib.escapeShellArg environmentFile} ]; then
-        return 1
-      fi
-      if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg environmentFile} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
-        return 1
-      fi
-      private_environment_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg environmentFile} )"
-      if (( (8#$private_environment_mode & 0077) != 0 )); then
-        return 1
-      fi
-      set -a
-      # shellcheck disable=SC1091
-      . ${lib.escapeShellArg environmentFile}
-      set +a
-      ${checkPrivateSettings privateServiceSettings}
-      ${validateDatabaseEnvironment}
-      validate_database_environment || return 1
-    }
-  '';
-
   waitForDatabase = ''
     attempt=0
     until ${pkgs.postgresql_18}/bin/pg_isready \
       -h 127.0.0.1 \
-      -p ${toString cfg.postgresPort} >/dev/null 2>&1; do
+      -p ${toString cfg.databasePort} >/dev/null 2>&1; do
       attempt=$((attempt + 1))
       if [ "$attempt" -ge 60 ]; then
-        printf 'Timed out waiting for local PostgreSQL readiness.\n' >&2
+        printf 'Timed out waiting for database readiness.\n' >&2
         exit 75
       fi
       ${pkgs.coreutils}/bin/sleep 1
     done
   '';
 
-  postgresClusterValidator =
-    (import ../../../lib/local-control/postgres-cluster-validator.nix { }).mkPostgresClusterValidator
-      pkgs;
+  databaseClusterValidator = localControlLibrary.mkDatabaseClusterValidator pkgs;
 
-  serviceGate = pkgs.writeShellApplication {
-    name = "local-control-service-gate";
-    runtimeInputs = [
-      pkgs.coreutils
-      pkgs.git
-    ];
-    text = ''
-      set -eu
-      if [ "$#" -lt 1 ]; then
-        printf 'A service command is required.\n' >&2
-        exit 64
-      fi
-      ${privateEnvironmentReady}
-      if ! private_environment_ready; then
-        printf 'Private service environment or preparation proof is not ready; run local-control-prepare after configuring it.\n' >&2
-        exit 0
-      fi
-      ${computePreparationState}
-      ${checkPreparationStamp}
-      if ! compute_preparation_state || ! preparation_stamp_matches; then
-        printf 'Local service preparation is stale; run local-control-prepare before starting services.\n' >&2
-        exit 0
-      fi
-      exec "$@"
-    '';
-  };
+  serviceGate = localControlLibrary.mkPreparationGate pkgs;
+  serviceGateArguments = [
+    "${serviceGate}/bin/local-control-service-gate"
+    (toString environmentFile)
+    preparationStamp
+    stateDir
+    launchConfigurationDigest
+    (if cfg.proxyEnable then "enabled" else "disabled")
+  ];
 
   runPrivateCommand = setting: ''
     ${requirePrivateSettings [ setting ]}
-    ${pkgs.bash}/bin/bash -o errexit -o pipefail -c "''${${setting}}"
+    ${secureFileSystem}/bin/local-control-secure-files exec-source \
+      "$LOCAL_CONTROL_PROJECT_DIRECTORY" \
+      ${pkgs.bash}/bin/bash -o errexit -o pipefail -c "''${${setting}}"
   '';
 
   execPrivateCommand = setting: ''
     ${requirePrivateSettings [ setting ]}
-    exec ${pkgs.bash}/bin/bash -o errexit -o pipefail -c "''${${setting}}"
+    ${cleanupPrivateEnvironment}
+    cleanup_private_environment
+    exec ${secureFileSystem}/bin/local-control-secure-files exec-source \
+      "$LOCAL_CONTROL_PROJECT_DIRECTORY" \
+      ${pkgs.bash}/bin/bash -o errexit -o pipefail -c "''${${setting}}"
   '';
 
-  caddyConfig = pkgs.writeText "local-control.Caddyfile" ''
+  proxyConfig = pkgs.writeText "local-control-proxy.conf" ''
     {
       admin off
       auto_https off
@@ -259,13 +290,13 @@ let
       }
     }
 
-    https://${cfg.hostOnlyAddress}:${toString cfg.agentPort} {
-      bind ${cfg.hostOnlyAddress}
-      tls ${pkiDir}/server.crt ${pkiDir}/server.key {
-        client_auth {
-          trust_pool file ${pkiDir}/ca.crt
-          mode require_and_verify
-        }
+      https://${cfg.bindAddress}:${toString cfg.proxyPort} {
+        bind ${cfg.bindAddress}
+        tls {$LOCAL_CONTROL_PROXY_CERT} {$LOCAL_CONTROL_PROXY_KEY} {
+          client_auth {
+          trust_pool file {$LOCAL_CONTROL_PROXY_CA}
+            mode require_and_verify
+          }
       }
       request_header -X-Client-Certificate-Fingerprint
       request_header -X-Agent-Proxy-Attestation
@@ -276,25 +307,49 @@ let
     }
   '';
 
-  postgres = pkgs.writeShellApplication {
-    name = "local-control-postgres";
+  serverCertificateExtensions = pkgs.writeText "local-control-server-extensions" ''
+    basicConstraints=critical,CA:FALSE
+    keyUsage=critical,digitalSignature,keyEncipherment
+    extendedKeyUsage=serverAuth
+        subjectAltName=IP:${cfg.bindAddress}
+  '';
+
+  clientCertificateExtensions = pkgs.writeText "local-control-client-extensions" ''
+    basicConstraints=critical,CA:FALSE
+    keyUsage=critical,digitalSignature,keyEncipherment
+    extendedKeyUsage=clientAuth
+  '';
+
+  database = pkgs.writeShellApplication {
+    name = "local-control-database";
     runtimeInputs = [
       pkgs.coreutils
       pkgs.postgresql_18
     ];
     text = ''
       set -eu
-      if ! ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster ${lib.escapeShellArg postgresDir}; then
-        printf 'Local PostgreSQL data directory is incomplete, unsafe, or corrupt.\n' >&2
+      if ! ${privatePathGuard}/bin/local-control-private-path validate-directory \
+        ${lib.escapeShellArg databaseDir} \
+        'Local database directory'; then
         exit 0
       fi
-      mkdir -p ${lib.escapeShellArg postgresSocketDir}
-      chmod 700 ${lib.escapeShellArg postgresSocketDir}
-      exec postgres \
-        -D ${lib.escapeShellArg postgresDir} \
+      if ! ${databaseClusterValidator}/bin/local-control-validate-database-cluster ${lib.escapeShellArg databaseDir}; then
+        printf 'Local database directory is incomplete, unsafe, or corrupt.\n' >&2
+        exit 0
+      fi
+      if ! ${privatePathGuard}/bin/local-control-private-path validate-directory \
+        ${lib.escapeShellArg databaseSocketDir} \
+        'Local database socket directory'; then
+        exit 0
+      fi
+      exec ${secureFileSystem}/bin/local-control-secure-files exec-cluster-socket \
+        ${lib.escapeShellArg databaseDir} 18 \
+        ${lib.escapeShellArg databaseSocketDir} \
+        ${pkgs.postgresql_18}/bin/postgres \
+        -D . \
         -h 127.0.0.1 \
-        -k ${lib.escapeShellArg postgresSocketDir} \
-        -p ${toString cfg.postgresPort}
+        -k @socket@ \
+        -p ${toString cfg.databasePort}
     '';
   };
 
@@ -313,7 +368,6 @@ let
       ${requirePrivateSettings [ "LOCAL_CONTROL_PROJECT_DIRECTORY" ]}
       ${requirePreparation}
       ${waitForDatabase}
-      cd "$LOCAL_CONTROL_PROJECT_DIRECTORY"
       ${runPrivateCommand "LOCAL_CONTROL_SCHEMA_COMMAND"}
       ${execPrivateCommand "LOCAL_CONTROL_API_COMMAND"}
     '';
@@ -338,7 +392,6 @@ let
       export OPENBLAS_NUM_THREADS=1
       export MKL_NUM_THREADS=1
       export VECLIB_MAXIMUM_THREADS=1
-      cd "$LOCAL_CONTROL_PROJECT_DIRECTORY"
       ${execPrivateCommand "LOCAL_CONTROL_WORKER_COMMAND"}
     '';
   };
@@ -356,7 +409,6 @@ let
       ${loadPrivateEnvironment}
       ${requirePrivateSettings [ "LOCAL_CONTROL_PROJECT_DIRECTORY" ]}
       ${requirePreparation}
-      cd "$LOCAL_CONTROL_PROJECT_DIRECTORY"
       ${execPrivateCommand "LOCAL_CONTROL_FRONTEND_COMMAND"}
     '';
   };
@@ -379,23 +431,21 @@ let
         "LOCAL_CONTROL_PREPARE_COMMAND"
         "LOCAL_CONTROL_PREPARATION_INPUT"
       ]}
-      cd "$LOCAL_CONTROL_PROJECT_DIRECTORY"
+      ${requirePrivateSettings privateServiceSettings}
       ${runPrivateCommand "LOCAL_CONTROL_PREPARE_COMMAND"}
       umask 077
-      if [ -L ${lib.escapeShellArg preparationStamp} ] || [ -e ${lib.escapeShellArg preparationStamp} ] && [ ! -f ${lib.escapeShellArg preparationStamp} ]; then
-        printf 'Preparation proof path must be a regular file.\n' >&2
-        exit 1
-      fi
       ${computePreparationState}
-      preparation_stamp_tmp="$(mktemp ${lib.escapeShellArg "${preparationStamp}.XXXXXX"})"
-      printf '%s\n' "$preparation_state" > "$preparation_stamp_tmp"
-      chmod 600 "$preparation_stamp_tmp"
-      mv -f "$preparation_stamp_tmp" ${lib.escapeShellArg preparationStamp}
+      compute_preparation_state
+      printf '%s\n' "$preparation_state" | \
+        ${secureFileSystem}/bin/local-control-secure-files atomic-write \
+          ${lib.escapeShellArg preparationStamp} 600
+      ${cleanupPrivateEnvironment}
+      cleanup_private_environment
     '';
   };
 
-  caddy = pkgs.writeShellApplication {
-    name = "local-control-caddy";
+  proxy = pkgs.writeShellApplication {
+    name = "local-control-proxy";
     runtimeInputs = [
       pkgs.caddy
       pkgs.coreutils
@@ -404,7 +454,12 @@ let
       set -eu
       ${loadPrivateEnvironment}
       ${requirePrivateSettings [ "SERVICE_PROXY_ATTESTATION" ]}
-      exec caddy run --config ${lib.escapeShellArg caddyConfig} --adapter caddyfile
+      ${cleanupPrivateEnvironment}
+      cleanup_private_environment
+      exec ${secureFileSystem}/bin/local-control-secure-files exec-proxy \
+        ${lib.escapeShellArg pkiDir} \
+        ${pkgs.caddy}/bin/caddy \
+        run --config ${lib.escapeShellArg proxyConfig} --adapter caddyfile
     '';
   };
 
@@ -421,16 +476,18 @@ let
       ${loadPrivateEnvironment}
       ${prepareDatabaseEnvironment}
       ${requirePrivateSettings [ "LOCAL_CONTROL_READINESS_URL" ]}
-      printf 'PostgreSQL: '
-      pg_isready -h 127.0.0.1 -p ${toString cfg.postgresPort}
-      printf '\nApplication: '
+      printf 'Database: '
+      pg_isready -h 127.0.0.1 -p ${toString cfg.databasePort}
+      printf '\nService: '
       curl --fail --silent --show-error "$LOCAL_CONTROL_READINESS_URL"
       printf '\n\nListeners:\n'
       lsof -nP \
-        -iTCP:${toString cfg.frontendPort} \
+        -iTCP:${toString cfg.webPort} \
         -iTCP:${toString cfg.apiPort} \
-        -iTCP:${toString cfg.agentPort} \
+        -iTCP:${toString cfg.proxyPort} \
         -sTCP:LISTEN || true
+      ${cleanupPrivateEnvironment}
+      cleanup_private_environment
     '';
   };
 
@@ -439,8 +496,8 @@ let
     text = ''
       set -eu
       domain="gui/$(id -u)"
-      for service in worker api frontend caddy; do
-        label="$domain/dev.ianmh.local-control-$service"
+      for service in worker api frontend proxy; do
+        label="$domain/local.services.local-control-$service"
         if launchctl print "$label" >/dev/null 2>&1; then
           launchctl kickstart -k "$label"
         fi
@@ -450,21 +507,21 @@ let
 in
 {
   options.services.localControl = {
-    enable = lib.mkEnableOption "private local application stack";
+    enable = lib.mkEnableOption "private local services";
 
     environmentFile = lib.mkOption {
       type = lib.types.path;
       default = "${config.xdg.stateHome}/local-control/environment";
-      description = "Owner-readable environment file for the private local services.";
+      description = "Owner-readable environment file for the private services.";
     };
 
-    hostOnlyAddress = lib.mkOption {
+    bindAddress = lib.mkOption {
       type = lib.types.str;
       default = "172.16.42.1";
-      description = "Host-only network address used by the private agent edge.";
+      description = "Address used by the optional private listener.";
     };
 
-    frontendPort = lib.mkOption {
+    webPort = lib.mkOption {
       type = lib.types.port;
       default = 5173;
     };
@@ -474,12 +531,12 @@ in
       default = 8788;
     };
 
-    agentPort = lib.mkOption {
+    proxyPort = lib.mkOption {
       type = lib.types.port;
       default = 8443;
     };
 
-    postgresPort = lib.mkOption {
+    databasePort = lib.mkOption {
       type = lib.types.port;
       default = 55433;
     };
@@ -487,7 +544,7 @@ in
     proxyEnable = lib.mkOption {
       type = lib.types.bool;
       default = true;
-      description = "Expose the private host-only mTLS edge for desktop clients.";
+      description = "Expose the optional authenticated listener for local clients.";
     };
   };
 
@@ -495,7 +552,7 @@ in
     assertions = [
       {
         assertion = isDarwin;
-        message = "services.localControl is implemented for the local macOS control host.";
+        message = "services.localControl requires a supported desktop host.";
       }
       {
         assertion = !(lib.hasPrefix "${builtins.storeDir}/" (toString cfg.environmentFile));
@@ -505,13 +562,13 @@ in
         assertion =
           builtins.length (
             lib.unique [
-              cfg.frontendPort
+              cfg.webPort
               cfg.apiPort
-              cfg.agentPort
-              cfg.postgresPort
+              cfg.proxyPort
+              cfg.databasePort
             ]
           ) == 4;
-        message = "services.localControl requires distinct frontend, API, agent, and PostgreSQL ports.";
+        message = "services.localControl requires distinct web, API, proxy, and database ports.";
       }
     ];
 
@@ -524,201 +581,286 @@ in
     home.activation.localControlState = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       set -eu
       umask 0077
-      state_dir_preexisting=false
-      if [ -L ${lib.escapeShellArg stateDir} ] || [ -e ${lib.escapeShellArg stateDir} ] && [ ! -d ${lib.escapeShellArg stateDir} ]; then
-        printf 'Local service state directory must be a real directory.\n' >&2
-        exit 1
-      fi
-      if [ -d ${lib.escapeShellArg stateDir} ]; then
-        state_dir_preexisting=true
-      fi
-      mkdir -p ${lib.escapeShellArg stateDir}
-      if [ "$state_dir_preexisting" = true ]; then
-        if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg stateDir} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
-          printf 'Local service state directory must be owned by the current user.\n' >&2
-          exit 1
-        fi
-        state_dir_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg stateDir} )"
-        if (( (8#$state_dir_mode & 0077) != 0 )); then
-          printf 'Local service state directory must not be accessible to group or others.\n' >&2
-          exit 1
-        fi
-      fi
-      chmod 700 ${lib.escapeShellArg stateDir}
+      ${privatePathGuard}/bin/local-control-private-path ensure-directory \
+        ${lib.escapeShellArg stateDir} \
+        'Local service state directory'
+      ${privatePathGuard}/bin/local-control-private-path ensure-directory \
+        ${lib.escapeShellArg databaseDir} \
+        'Local database directory'
 
-      postgres_dir_preexisting=false
-      if [ -L ${lib.escapeShellArg postgresDir} ] || [ -e ${lib.escapeShellArg postgresDir} ] && [ ! -d ${lib.escapeShellArg postgresDir} ]; then
-        printf 'Refusing a symlinked or non-directory PostgreSQL data path.\n' >&2
+      database_state="$(${secureFileSystem}/bin/local-control-secure-files cluster-state \
+        ${lib.escapeShellArg databaseDir} 18)" || {
+        printf 'Refusing an incomplete, unsafe, or incompatible database directory.\n' >&2
         exit 1
-      fi
-      if [ -d ${lib.escapeShellArg postgresDir} ]; then
-        postgres_dir_preexisting=true
-      else
-        mkdir ${lib.escapeShellArg postgresDir}
-      fi
-      if [ "$postgres_dir_preexisting" = true ]; then
-        if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg postgresDir} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
-          printf 'Refusing a PostgreSQL data directory not owned by the current user.\n' >&2
-          exit 1
-        fi
-        postgres_dir_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg postgresDir} )"
-        if (( (8#$postgres_dir_mode & 0077) != 0 )); then
-          printf 'Refusing a PostgreSQL data directory accessible to group or others.\n' >&2
-          exit 1
-        fi
-      fi
-      chmod 700 ${lib.escapeShellArg postgresDir}
-
-      postgres_version_file=${lib.escapeShellArg "${postgresDir}/PG_VERSION"}
-      if [ -L "$postgres_version_file" ] || [ -e "$postgres_version_file" ] && [ ! -f "$postgres_version_file" ]; then
-        printf 'Refusing an invalid PostgreSQL cluster marker.\n' >&2
-        exit 1
-      fi
-      if [ -f "$postgres_version_file" ]; then
-        if ! ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster ${lib.escapeShellArg postgresDir}; then
-          printf 'Refusing an incomplete, unsafe, or corrupt PostgreSQL data directory.\n' >&2
-          exit 1
-        fi
-      elif [ -n "$( ${pkgs.findutils}/bin/find ${lib.escapeShellArg postgresDir} -mindepth 1 -maxdepth 1 -print -quit )" ]; then
-        printf 'Refusing to initialize a non-empty PostgreSQL data directory without a valid cluster marker.\n' >&2
-        exit 1
-      else
-        ${pkgs.postgresql_18}/bin/initdb \
-          --pgdata=${lib.escapeShellArg postgresDir} \
+      }
+      if [ "$database_state" = missing ]; then
+        if ! ${secureFileSystem}/bin/local-control-secure-files initialize-cluster \
+          ${lib.escapeShellArg databaseDir} \
+          18 \
+          ${pkgs.postgresql_18}/bin/initdb \
+          --pgdata=. \
           --auth-local=trust \
           --auth-host=scram-sha-256 \
           --encoding=UTF8 \
-          --no-locale
-        if ! ${postgresClusterValidator}/bin/local-control-validate-postgres-cluster ${lib.escapeShellArg postgresDir}; then
-          printf 'PostgreSQL initialization did not produce a valid cluster.\n' >&2
+          --no-locale; then
+          printf 'Refusing to initialize an unsafe database directory.\n' >&2
           exit 1
         fi
       fi
 
-      if [ -e ${lib.escapeShellArg environmentFile} ] || [ -L ${lib.escapeShellArg environmentFile} ]; then
-        if [ -L ${lib.escapeShellArg environmentFile} ] || [ ! -f ${lib.escapeShellArg environmentFile} ]; then
-          printf 'Private service environment must be a regular file.\n' >&2
-          exit 1
-        fi
-        if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' ${lib.escapeShellArg environmentFile} )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
-          printf 'Private service environment must be owned by the current user.\n' >&2
-          exit 1
-        fi
-        environment_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' ${lib.escapeShellArg environmentFile} )"
-        if (( (8#$environment_mode & 0077) != 0 )); then
-          printf 'Private service environment must not be readable by group or others.\n' >&2
-          exit 1
-        fi
-      else
+      environment_file_state="$(${secureFileSystem}/bin/local-control-secure-files inspect-file \
+        ${lib.escapeShellArg (toString environmentFile)} 600)" || {
+        printf 'Private service environment must be a safe regular file.\n' >&2
+        exit 1
+      }
+      if [ "$environment_file_state" = missing ]; then
         printf 'Private service environment is not configured; services remain gated until it is created by the owner.\n' >&2
       fi
 
-      mkdir -p \
-        ${lib.escapeShellArg postgresSocketDir} \
+      ${privatePathGuard}/bin/local-control-private-path ensure-directory \
+        ${lib.escapeShellArg databaseSocketDir} \
+        'Local database socket directory'
+      ${privatePathGuard}/bin/local-control-private-path ensure-directory \
         ${lib.escapeShellArg pkiDir} \
-        ${lib.escapeShellArg logDir}
-      chmod 700 \
-        ${lib.escapeShellArg postgresSocketDir} \
-        ${lib.escapeShellArg pkiDir} \
-        ${lib.escapeShellArg logDir}
+        'Local service PKI directory'
+      ${privatePathGuard}/bin/local-control-private-path ensure-directory \
+        ${lib.escapeShellArg logDir} \
+        'Local service log directory'
 
-      if [ ! -f ${lib.escapeShellArg "${pkiDir}/ca.crt"} ]; then
-        ${pkgs.openssl}/bin/openssl req -x509 -new -nodes -sha256 -days 3650 \
+      check_optional_generated_file() {
+        if ! ${secureFileSystem}/bin/local-control-secure-files inspect-file "$1" "$2" >/dev/null; then
+          printf 'Generated path is missing, unsafe, or has the wrong mode: %s\n' "$1" >&2
+          exit 1
+        fi
+      }
+
+      repair_log_file_mode() {
+        if ! ${secureFileSystem}/bin/local-control-secure-files repair-file-mode "$1" "$2" >/dev/null; then
+          printf 'Service log is missing, unsafe, or could not be made private: %s\n' "$1" >&2
+          exit 1
+        fi
+      }
+
+      ${lib.concatMapStringsSep "\n"
+        ({ path, mode }: ''
+          check_optional_generated_file \
+            ${lib.escapeShellArg path} \
+            ${lib.escapeShellArg mode}
+        '')
+        [
+          {
+            path = "${pkiDir}/ca.key";
+            mode = "600";
+          }
+          {
+            path = "${pkiDir}/ca.crt";
+            mode = "644";
+          }
+          {
+            path = "${pkiDir}/ca.srl";
+            mode = "600";
+          }
+          {
+            path = "${pkiDir}/server.key";
+            mode = "600";
+          }
+          {
+            path = "${pkiDir}/server.crt";
+            mode = "644";
+          }
+          {
+            path = "${pkiDir}/server.csr";
+            mode = "600";
+          }
+          {
+            path = "${pkiDir}/client.key";
+            mode = "600";
+          }
+          {
+            path = "${pkiDir}/client.crt";
+            mode = "644";
+          }
+          {
+            path = "${pkiDir}/client.csr";
+            mode = "600";
+          }
+          {
+            path = "${pkiDir}/client.pfx";
+            mode = "600";
+          }
+        ]
+      }
+      ${lib.concatMapStringsSep "\n"
+        (path: ''
+          repair_log_file_mode \
+            ${lib.escapeShellArg path} \
+            600
+        '')
+        [
+          "${logDir}/database.out.log"
+          "${logDir}/database.err.log"
+          "${logDir}/api.out.log"
+          "${logDir}/api.err.log"
+          "${logDir}/worker.out.log"
+          "${logDir}/worker.err.log"
+          "${logDir}/frontend.out.log"
+          "${logDir}/frontend.err.log"
+          "${logDir}/proxy.out.log"
+          "${logDir}/proxy.err.log"
+        ]
+      }
+
+      ca_certificate_state="$(${secureFileSystem}/bin/local-control-secure-files inspect-file \
+        ${lib.escapeShellArg "${pkiDir}/ca.crt"} 644)" || exit 1
+      ca_key_state="$(${secureFileSystem}/bin/local-control-secure-files inspect-file \
+        ${lib.escapeShellArg "${pkiDir}/ca.key"} 600)" || exit 1
+      if [ "$ca_certificate_state" = missing ] && [ "$ca_key_state" = missing ]; then
+        ${secureFileSystem}/bin/local-control-secure-files exec-files \
+          ${lib.escapeShellArg pkiDir} \
+          ${pkgs.openssl}/bin/openssl \
+          --create ca.key 600 \
+          --create ca.crt 644 \
+          -- \
+          req -x509 -new -nodes -sha256 -days 3650 \
           -newkey rsa:3072 \
-          -keyout ${lib.escapeShellArg "${pkiDir}/ca.key"} \
-          -out ${lib.escapeShellArg "${pkiDir}/ca.crt"} \
+          -keyout @ca.key@ \
+          -out @ca.crt@ \
           -subj '/CN=Local Service CA' \
           -addext 'basicConstraints=critical,CA:TRUE' \
           -addext 'keyUsage=critical,keyCertSign,cRLSign'
-        chmod 600 ${lib.escapeShellArg "${pkiDir}/ca.key"}
-        chmod 644 ${lib.escapeShellArg "${pkiDir}/ca.crt"}
+      elif [ "$ca_certificate_state" = missing ] || [ "$ca_key_state" = missing ]; then
+        printf 'The local service CA is incomplete.\n' >&2
+        exit 1
       fi
 
-      if [ ! -f ${lib.escapeShellArg "${pkiDir}/server.crt"} ]; then
-        certificate_extensions="$(${pkgs.coreutils}/bin/mktemp ${lib.escapeShellArg "${stateDir}/server-ext.XXXXXX"})"
-        cat > "$certificate_extensions" <<'EOF'
-      basicConstraints=critical,CA:FALSE
-      keyUsage=critical,digitalSignature,keyEncipherment
-      extendedKeyUsage=serverAuth
-      subjectAltName=IP:${cfg.hostOnlyAddress}
-      EOF
-        ${pkgs.openssl}/bin/openssl req -new -nodes -newkey rsa:3072 \
-          -keyout ${lib.escapeShellArg "${pkiDir}/server.key"} \
-          -out ${lib.escapeShellArg "${pkiDir}/server.csr"} \
-          -subj '/CN=${cfg.hostOnlyAddress}'
-        ${pkgs.openssl}/bin/openssl x509 -req -sha256 -days 825 \
-          -in ${lib.escapeShellArg "${pkiDir}/server.csr"} \
-          -CA ${lib.escapeShellArg "${pkiDir}/ca.crt"} \
-          -CAkey ${lib.escapeShellArg "${pkiDir}/ca.key"} \
-          -CAcreateserial \
-          -out ${lib.escapeShellArg "${pkiDir}/server.crt"} \
-          -extfile "$certificate_extensions"
-        ${pkgs.coreutils}/bin/rm -f "$certificate_extensions"
-        chmod 600 ${lib.escapeShellArg "${pkiDir}/server.key"}
-        chmod 644 ${lib.escapeShellArg "${pkiDir}/server.crt"}
+      ca_serial_state="$(${secureFileSystem}/bin/local-control-secure-files inspect-file \
+        ${lib.escapeShellArg "${pkiDir}/ca.srl"} 600)" || exit 1
+      if [ "$ca_serial_state" = missing ]; then
+        printf '01\n' | ${secureFileSystem}/bin/local-control-secure-files create-file \
+          ${lib.escapeShellArg "${pkiDir}/ca.srl"} 600
       fi
 
-      if [ ! -f ${lib.escapeShellArg "${pkiDir}/desktop-client.pfx"} ]; then
-        certificate_extensions="$(${pkgs.coreutils}/bin/mktemp ${lib.escapeShellArg "${stateDir}/client-ext.XXXXXX"})"
-        cat > "$certificate_extensions" <<'EOF'
-      basicConstraints=critical,CA:FALSE
-      keyUsage=critical,digitalSignature,keyEncipherment
-      extendedKeyUsage=clientAuth
-      EOF
-        ${pkgs.openssl}/bin/openssl req -new -nodes -newkey rsa:3072 \
-          -keyout ${lib.escapeShellArg "${pkiDir}/desktop-client.key"} \
-          -out ${lib.escapeShellArg "${pkiDir}/desktop-client.csr"} \
-          -subj '/CN=desktop-client'
-        ${pkgs.openssl}/bin/openssl x509 -req -sha256 -days 825 \
-          -in ${lib.escapeShellArg "${pkiDir}/desktop-client.csr"} \
-          -CA ${lib.escapeShellArg "${pkiDir}/ca.crt"} \
-          -CAkey ${lib.escapeShellArg "${pkiDir}/ca.key"} \
-          -CAcreateserial \
-          -out ${lib.escapeShellArg "${pkiDir}/desktop-client.crt"} \
-          -extfile "$certificate_extensions"
-        ${pkgs.openssl}/bin/openssl pkcs12 -export \
-          -out ${lib.escapeShellArg "${pkiDir}/desktop-client.pfx"} \
-          -inkey ${lib.escapeShellArg "${pkiDir}/desktop-client.key"} \
-          -in ${lib.escapeShellArg "${pkiDir}/desktop-client.crt"} \
-          -certfile ${lib.escapeShellArg "${pkiDir}/ca.crt"} \
+      server_certificate_state="$(${secureFileSystem}/bin/local-control-secure-files inspect-file \
+        ${lib.escapeShellArg "${pkiDir}/server.crt"} 644)" || exit 1
+      server_key_state="$(${secureFileSystem}/bin/local-control-secure-files inspect-file \
+        ${lib.escapeShellArg "${pkiDir}/server.key"} 600)" || exit 1
+      if [ "$server_certificate_state" = missing ] && [ "$server_key_state" = missing ]; then
+        ${secureFileSystem}/bin/local-control-secure-files exec-files \
+          ${lib.escapeShellArg pkiDir} \
+          ${pkgs.openssl}/bin/openssl \
+          --create server.key 600 \
+          --create server.csr 600 \
+          -- \
+          req -new -nodes -newkey rsa:3072 \
+          -keyout @server.key@ \
+          -out @server.csr@ \
+          -subj '/CN=local-service'
+        ${secureFileSystem}/bin/local-control-secure-files exec-files \
+          ${lib.escapeShellArg pkiDir} \
+          ${pkgs.openssl}/bin/openssl \
+          --read ca.crt 644 \
+          --read ca.key 600 \
+          --update ca.srl 600 \
+          --read server.csr 600 \
+          --create server.crt 644 \
+          -- \
+          x509 -req -sha256 -days 825 \
+          -in @server.csr@ \
+          -CA @ca.crt@ \
+          -CAkey @ca.key@ \
+          -CAserial @ca.srl@ \
+          -out @server.crt@ \
+          -extfile ${lib.escapeShellArg serverCertificateExtensions}
+      elif [ "$server_certificate_state" = missing ] || [ "$server_key_state" = missing ]; then
+        printf 'The local service server identity is incomplete.\n' >&2
+        exit 1
+      fi
+
+      client_bundle_state="$(${secureFileSystem}/bin/local-control-secure-files inspect-file \
+        ${lib.escapeShellArg "${pkiDir}/client.pfx"} 600)" || exit 1
+      client_key_state="$(${secureFileSystem}/bin/local-control-secure-files inspect-file \
+        ${lib.escapeShellArg "${pkiDir}/client.key"} 600)" || exit 1
+      client_certificate_state="$(${secureFileSystem}/bin/local-control-secure-files inspect-file \
+        ${lib.escapeShellArg "${pkiDir}/client.crt"} 644)" || exit 1
+      if [ "$client_bundle_state" = missing ] \
+        && [ "$client_key_state" = missing ] \
+        && [ "$client_certificate_state" = missing ]; then
+        ${secureFileSystem}/bin/local-control-secure-files exec-files \
+          ${lib.escapeShellArg pkiDir} \
+          ${pkgs.openssl}/bin/openssl \
+          --create client.key 600 \
+          --create client.csr 600 \
+          -- \
+          req -new -nodes -newkey rsa:3072 \
+          -keyout @client.key@ \
+          -out @client.csr@ \
+          -subj '/CN=local-client'
+        ${secureFileSystem}/bin/local-control-secure-files exec-files \
+          ${lib.escapeShellArg pkiDir} \
+          ${pkgs.openssl}/bin/openssl \
+          --read ca.crt 644 \
+          --read ca.key 600 \
+          --update ca.srl 600 \
+          --read client.csr 600 \
+          --create client.crt 644 \
+          -- \
+          x509 -req -sha256 -days 825 \
+          -in @client.csr@ \
+          -CA @ca.crt@ \
+          -CAkey @ca.key@ \
+          -CAserial @ca.srl@ \
+          -out @client.crt@ \
+          -extfile ${lib.escapeShellArg clientCertificateExtensions}
+        ${secureFileSystem}/bin/local-control-secure-files exec-files \
+          ${lib.escapeShellArg pkiDir} \
+          ${pkgs.openssl}/bin/openssl \
+          --read ca.crt 644 \
+          --read client.key 600 \
+          --read client.crt 644 \
+          --create client.pfx 600 \
+          -- \
+          pkcs12 -export \
+          -out @client.pfx@ \
+          -inkey @client.key@ \
+          -in @client.crt@ \
+          -certfile @ca.crt@ \
           -passout pass:
-        ${pkgs.coreutils}/bin/rm -f "$certificate_extensions"
-        chmod 600 \
-          ${lib.escapeShellArg "${pkiDir}/desktop-client.key"} \
-          ${lib.escapeShellArg "${pkiDir}/desktop-client.pfx"}
-        chmod 644 ${lib.escapeShellArg "${pkiDir}/desktop-client.crt"}
+      elif [ "$client_bundle_state" = missing ] \
+        || [ "$client_key_state" = missing ] \
+        || [ "$client_certificate_state" = missing ]; then
+        printf 'The local service client identity is incomplete.\n' >&2
+        exit 1
       fi
     '';
 
-    launchd.agents.local-control-postgres = {
+    launchd.agents.local-control-database = {
       enable = true;
       config = {
-        Label = "dev.ianmh.local-control-postgres";
-        ProgramArguments = [ "${postgres}/bin/local-control-postgres" ];
+        Label = "local.services.local-control-database";
+        ProgramArguments = [ "${database}/bin/local-control-database" ];
         RunAtLoad = true;
         KeepAlive = {
           SuccessfulExit = false;
         };
         ThrottleInterval = 10;
+        Umask = 63;
         ProcessType = "Background";
-        StandardOutPath = "${logDir}/postgres.out.log";
-        StandardErrorPath = "${logDir}/postgres.err.log";
+        StandardOutPath = "${logDir}/database.out.log";
+        StandardErrorPath = "${logDir}/database.err.log";
       };
     };
 
     launchd.agents.local-control-api = {
       enable = true;
       config = {
-        Label = "dev.ianmh.local-control-api";
-        ProgramArguments = [
-          "${serviceGate}/bin/local-control-service-gate"
-          "${api}/bin/local-control-api"
-        ];
+        Label = "local.services.local-control-api";
+        ProgramArguments = serviceGateArguments ++ [ "${api}/bin/local-control-api" ];
         RunAtLoad = true;
         KeepAlive = {
           SuccessfulExit = false;
         };
         ThrottleInterval = 10;
+        Umask = 63;
         ProcessType = "Background";
         StandardOutPath = "${logDir}/api.out.log";
         StandardErrorPath = "${logDir}/api.err.log";
@@ -728,16 +870,14 @@ in
     launchd.agents.local-control-worker = {
       enable = true;
       config = {
-        Label = "dev.ianmh.local-control-worker";
-        ProgramArguments = [
-          "${serviceGate}/bin/local-control-service-gate"
-          "${worker}/bin/local-control-worker"
-        ];
+        Label = "local.services.local-control-worker";
+        ProgramArguments = serviceGateArguments ++ [ "${worker}/bin/local-control-worker" ];
         RunAtLoad = true;
         KeepAlive = {
           SuccessfulExit = false;
         };
         ThrottleInterval = 10;
+        Umask = 63;
         ProcessType = "Interactive";
         StandardOutPath = "${logDir}/worker.out.log";
         StandardErrorPath = "${logDir}/worker.err.log";
@@ -747,38 +887,34 @@ in
     launchd.agents.local-control-frontend = {
       enable = true;
       config = {
-        Label = "dev.ianmh.local-control-frontend";
-        ProgramArguments = [
-          "${serviceGate}/bin/local-control-service-gate"
-          "${frontend}/bin/local-control-frontend"
-        ];
+        Label = "local.services.local-control-frontend";
+        ProgramArguments = serviceGateArguments ++ [ "${frontend}/bin/local-control-frontend" ];
         RunAtLoad = true;
         KeepAlive = {
           SuccessfulExit = false;
         };
         ThrottleInterval = 10;
+        Umask = 63;
         ProcessType = "Background";
         StandardOutPath = "${logDir}/frontend.out.log";
         StandardErrorPath = "${logDir}/frontend.err.log";
       };
     };
 
-    launchd.agents.local-control-caddy = lib.mkIf cfg.proxyEnable {
+    launchd.agents.local-control-proxy = lib.mkIf cfg.proxyEnable {
       enable = true;
       config = {
-        Label = "dev.ianmh.local-control-caddy";
-        ProgramArguments = [
-          "${serviceGate}/bin/local-control-service-gate"
-          "${caddy}/bin/local-control-caddy"
-        ];
+        Label = "local.services.local-control-proxy";
+        ProgramArguments = serviceGateArguments ++ [ "${proxy}/bin/local-control-proxy" ];
         RunAtLoad = true;
         KeepAlive = {
           SuccessfulExit = false;
         };
         ThrottleInterval = 10;
+        Umask = 63;
         ProcessType = "Background";
-        StandardOutPath = "${logDir}/caddy.out.log";
-        StandardErrorPath = "${logDir}/caddy.err.log";
+        StandardOutPath = "${logDir}/proxy.out.log";
+        StandardErrorPath = "${logDir}/proxy.err.log";
       };
     };
   };

--- a/lib/local-control/postgres-cluster-validator.nix
+++ b/lib/local-control/postgres-cluster-validator.nix
@@ -1,0 +1,60 @@
+_: {
+  mkPostgresClusterValidator =
+    pkgs:
+    pkgs.writeShellApplication {
+      name = "local-control-validate-postgres-cluster";
+      runtimeInputs = [
+        pkgs.coreutils
+        pkgs.postgresql_18
+      ];
+      text = ''
+        set -euo pipefail
+        if [ "$#" -ne 1 ]; then
+          printf 'Exactly one PostgreSQL data directory is required.\n' >&2
+          exit 64
+        fi
+
+        postgres_data_dir="$1"
+        if [ -L "$postgres_data_dir" ] || [ ! -d "$postgres_data_dir" ]; then
+          exit 1
+        fi
+        if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' "$postgres_data_dir" )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
+          exit 1
+        fi
+        postgres_dir_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' "$postgres_data_dir" )"
+        if (( (8#$postgres_dir_mode & 0077) != 0 )); then
+          exit 1
+        fi
+        for postgres_control_file in PG_VERSION postgresql.conf pg_hba.conf pg_ident.conf; do
+          postgres_control_path="$postgres_data_dir/$postgres_control_file"
+          if [ -L "$postgres_control_path" ] || [ ! -f "$postgres_control_path" ]; then
+            exit 1
+          fi
+          if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' "$postgres_control_path" )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
+            exit 1
+          fi
+          postgres_control_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' "$postgres_control_path" )"
+          if (( (8#$postgres_control_mode & 0077) != 0 )); then
+            exit 1
+          fi
+        done
+        for postgres_control_dir in base global pg_wal; do
+          postgres_control_path="$postgres_data_dir/$postgres_control_dir"
+          if [ -L "$postgres_control_path" ] || [ ! -d "$postgres_control_path" ]; then
+            exit 1
+          fi
+          if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' "$postgres_control_path" )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
+            exit 1
+          fi
+          postgres_control_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' "$postgres_control_path" )"
+          if (( (8#$postgres_control_mode & 0077) != 0 )); then
+            exit 1
+          fi
+        done
+        postgres_major=""
+        IFS= read -r postgres_major < "$postgres_data_dir/PG_VERSION" || true
+        [ "$postgres_major" = 18 ] || exit 1
+        ${pkgs.postgresql_18}/bin/pg_controldata "$postgres_data_dir" >/dev/null 2>&1
+      '';
+    };
+}

--- a/lib/local-control/postgres-cluster-validator.nix
+++ b/lib/local-control/postgres-cluster-validator.nix
@@ -1,60 +1,490 @@
-_: {
-  mkPostgresClusterValidator =
+_:
+let
+  mkSecureFileSystem =
     pkgs:
+    pkgs.stdenv.mkDerivation {
+      pname = "local-control-secure-files";
+      version = "1";
+      src = ./secure-files.c;
+      dontUnpack = true;
+      dontConfigure = true;
+      dontBuild = true;
+      installPhase = ''
+        mkdir -p "$out/bin"
+        "$CC" -std=c11 -D_GNU_SOURCE -Wall -Wextra -Werror \
+          "$src" \
+          -o "$out/bin/local-control-secure-files"
+      '';
+    };
+
+  mkEnvironmentSnapshot =
+    pkgs:
+    let
+      secureFileSystem = mkSecureFileSystem pkgs;
+    in
     pkgs.writeShellApplication {
-      name = "local-control-validate-postgres-cluster";
+      name = "local-control-environment-snapshot";
       runtimeInputs = [
         pkgs.coreutils
+        secureFileSystem
+      ];
+      text = ''
+        set -euo pipefail
+
+        if [ "$#" -ne 3 ] || [ "$1" != read ]; then
+          printf 'Usage: local-control-environment-snapshot read ENVIRONMENT_FILE PROXY_MODE\n' >&2
+          exit 64
+        fi
+
+        environment_file="$2"
+        proxy_mode="$3"
+        case "$proxy_mode" in
+          enabled|disabled)
+            ;;
+          *)
+            printf 'The environment snapshot received an invalid proxy mode.\n' >&2
+            exit 64
+            ;;
+        esac
+
+        required_settings=(
+          LOCAL_CONTROL_PROJECT_DIRECTORY
+          LOCAL_CONTROL_DATABASE_URL
+          LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE
+          LOCAL_CONTROL_SCHEMA_COMMAND
+          LOCAL_CONTROL_API_COMMAND
+          LOCAL_CONTROL_WORKER_COMMAND
+          LOCAL_CONTROL_FRONTEND_COMMAND
+          LOCAL_CONTROL_PREPARE_COMMAND
+          LOCAL_CONTROL_PREPARATION_INPUT
+          LOCAL_CONTROL_READINESS_URL
+        )
+        if [ "$proxy_mode" = enabled ]; then
+          required_settings+=(SERVICE_PROXY_ATTESTATION)
+        fi
+
+        for required_setting in "''${required_settings[@]}"; do
+          unset "$required_setting"
+        done
+        unset SERVICE_PROXY_ATTESTATION
+
+        environment_snapshot_tmp="$(${pkgs.coreutils}/bin/mktemp)"
+        trap '${pkgs.coreutils}/bin/rm -f "$environment_snapshot_tmp"' EXIT
+        ${secureFileSystem}/bin/local-control-secure-files read-file \
+          "$environment_file" 600 > "$environment_snapshot_tmp"
+
+        environment_seen='|'
+        while IFS= read -r environment_line || [ -n "$environment_line" ]; do
+          case "$environment_line" in
+            ""|\#*)
+              continue
+              ;;
+          esac
+          case "$environment_line" in
+            *$'\r'*)
+              printf 'The environment file contains a carriage return.\n' >&2
+              exit 78
+              ;;
+            *=*)
+              environment_name="''${environment_line%%=*}"
+              environment_value="''${environment_line#*=}"
+              ;;
+            *)
+              printf 'The environment file must contain only NAME=VALUE records.\n' >&2
+              exit 78
+              ;;
+          esac
+          case "$environment_name" in
+            LOCAL_CONTROL_PROJECT_DIRECTORY|LOCAL_CONTROL_DATABASE_URL|LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE|LOCAL_CONTROL_SCHEMA_COMMAND|LOCAL_CONTROL_API_COMMAND|LOCAL_CONTROL_WORKER_COMMAND|LOCAL_CONTROL_FRONTEND_COMMAND|LOCAL_CONTROL_PREPARE_COMMAND|LOCAL_CONTROL_PREPARATION_INPUT|LOCAL_CONTROL_READINESS_URL)
+              ;;
+            SERVICE_PROXY_ATTESTATION)
+              if [ "$proxy_mode" != enabled ]; then
+                printf 'The environment file contains a proxy setting while the proxy is disabled.\n' >&2
+                exit 78
+              fi
+              ;;
+            *)
+              printf 'The environment file contains an unsupported setting: %s\n' "$environment_name" >&2
+              exit 78
+              ;;
+          esac
+          case "$environment_seen" in
+            *"|$environment_name|"*)
+              printf 'The environment file contains a duplicate setting: %s\n' "$environment_name" >&2
+              exit 78
+              ;;
+          esac
+          environment_seen="''${environment_seen}''${environment_name}|"
+          export "$environment_name=$environment_value"
+        done < "$environment_snapshot_tmp"
+
+        for required_setting in "''${required_settings[@]}"; do
+          if [ -z "''${!required_setting:-}" ]; then
+            printf 'The environment file is missing a required setting: %s\n' "$required_setting" >&2
+            exit 78
+          fi
+        done
+
+        ${pkgs.coreutils}/bin/cat "$environment_snapshot_tmp"
+      '';
+    };
+
+  mkSourceTreeSnapshot =
+    pkgs:
+    pkgs.writeShellApplication {
+      name = "local-control-source-snapshot";
+      runtimeInputs = [
+        pkgs.coreutils
+        (mkSecureFileSystem pkgs)
+      ];
+      text = ''
+        set -euo pipefail
+        export LC_ALL=C
+
+        if [ "$#" -ne 1 ]; then
+          printf 'Exactly one source directory is required.\n' >&2
+          exit 64
+        fi
+        ${mkSecureFileSystem pkgs}/bin/local-control-secure-files snapshot-tree "$1"
+      '';
+    };
+
+  mkPreparationProof =
+    pkgs:
+    let
+      environmentSnapshot = mkEnvironmentSnapshot pkgs;
+      secureFileSystem = mkSecureFileSystem pkgs;
+    in
+    pkgs.writeShellApplication {
+      name = "local-control-preparation-proof";
+      runtimeInputs = [
+        pkgs.coreutils
+        pkgs.git
+        environmentSnapshot
+        secureFileSystem
+      ];
+      text = ''
+                set -euo pipefail
+                export LC_ALL=C
+
+                if [ "$#" -ne 4 ] || [ "$1" != compute ]; then
+                  printf 'Usage: local-control-preparation-proof compute STATIC_DIGEST PROXY_MODE ENVIRONMENT_FILE\n' >&2
+                  exit 64
+                fi
+
+                static_configuration_digest="$2"
+                proxy_mode="$3"
+                environment_file="$4"
+                case "$proxy_mode" in
+                  enabled|disabled)
+                    ;;
+                  *)
+                    printf 'The preparation proof received an invalid proxy mode.\n' >&2
+                    exit 64
+                    ;;
+                esac
+
+                required_settings=(
+                  LOCAL_CONTROL_PROJECT_DIRECTORY
+                  LOCAL_CONTROL_DATABASE_URL
+                  LOCAL_CONTROL_DATABASE_ENVIRONMENT_VARIABLE
+                  LOCAL_CONTROL_SCHEMA_COMMAND
+                  LOCAL_CONTROL_API_COMMAND
+                  LOCAL_CONTROL_WORKER_COMMAND
+                  LOCAL_CONTROL_FRONTEND_COMMAND
+                  LOCAL_CONTROL_PREPARE_COMMAND
+                  LOCAL_CONTROL_PREPARATION_INPUT
+                  LOCAL_CONTROL_READINESS_URL
+                )
+                if [ "$proxy_mode" = enabled ]; then
+                  required_settings+=(SERVICE_PROXY_ATTESTATION)
+                fi
+                for required_setting in "''${required_settings[@]}"; do
+                  unset "$required_setting"
+                done
+                unset SERVICE_PROXY_ATTESTATION
+
+                proof_environment_snapshot="$(${pkgs.coreutils}/bin/mktemp)"
+                trap '${pkgs.coreutils}/bin/rm -f "$proof_environment_snapshot"' EXIT
+                ${environmentSnapshot}/bin/local-control-environment-snapshot read \
+                  "$environment_file" "$proxy_mode" > "$proof_environment_snapshot"
+
+                environment_seen='|'
+                while IFS= read -r environment_line || [ -n "$environment_line" ]; do
+                  case "$environment_line" in
+                    ""|\#*)
+                      continue
+                      ;;
+                    *=*)
+                      environment_name="''${environment_line%%=*}"
+                      environment_value="''${environment_line#*=}"
+                      ;;
+                    *)
+                      printf 'The environment file must contain only NAME=VALUE records.\n' >&2
+                      exit 78
+                      ;;
+                  esac
+                  case "$environment_seen" in
+                    *"|$environment_name|"*)
+                      printf 'The environment file contains a duplicate setting: %s\n' "$environment_name" >&2
+                      exit 78
+                      ;;
+                  esac
+                  environment_seen="''${environment_seen}''${environment_name}|"
+                  export "$environment_name=$environment_value"
+                done < "$proof_environment_snapshot"
+
+                for required_setting in "''${required_settings[@]}"; do
+                  if [ -z "''${!required_setting:-}" ]; then
+                    printf 'A required service setting is missing.\n' >&2
+                    exit 78
+                  fi
+                done
+
+                preparation_project_directory="$LOCAL_CONTROL_PROJECT_DIRECTORY"
+                # shellcheck disable=SC2016
+                source_identity="$(${secureFileSystem}/bin/local-control-secure-files exec-source \
+                  "$preparation_project_directory" \
+                  ${pkgs.bash}/bin/bash -c ${pkgs.lib.escapeShellArg ''
+                    set -euo pipefail
+                    # shellcheck disable=SC2016
+                    export LC_ALL=C
+                    [ -z "$(git -C . rev-parse --show-prefix 2>/dev/null)" ] || {
+                      printf 'The preparation source must be the Git checkout root.\n' >&2
+                      exit 78
+                    }
+                    source_revision="$(git -C . rev-parse --verify 'HEAD^{commit}' 2>/dev/null)" || {
+                      printf 'The Git checkout does not have a known committed revision.\n' >&2
+                      exit 78
+                    }
+                    case "$source_revision" in
+                      ""|*[!0-9a-fA-F]*)
+                        printf 'The Git revision is not a valid commit identifier.\n' >&2
+                        exit 78
+                        ;;
+                    esac
+                    git -C . cat-file -e "$source_revision^{commit}" 2>/dev/null || {
+                      printf 'The Git revision could not be verified as a commit.\n' >&2
+                      exit 78
+                    }
+                    source_files_digest="$(${secureFileSystem}/bin/local-control-secure-files snapshot-tree . | \
+                      ${pkgs.coreutils}/bin/sha256sum | \
+                      ${pkgs.coreutils}/bin/cut -d ' ' -f 1)" || {
+                      printf 'The source tree could not be snapshotted safely.\n' >&2
+                      exit 78
+                    }
+                    source_revision_after="$(git -C . rev-parse --verify 'HEAD^{commit}' 2>/dev/null)" || {
+                      printf 'The Git checkout changed while it was being snapshotted.\n' >&2
+                      exit 78
+                    }
+                    [ "$source_revision" = "$source_revision_after" ] || {
+                      printf 'The Git checkout changed while it was being snapshotted.\n' >&2
+                      exit 78
+                    }
+                    printf '%s %s\n' "$source_revision" "$source_files_digest"
+                  ''})" || {
+                  printf 'The project directory could not be opened as a stable source root.\n' >&2
+                  exit 78
+                }
+                read -r preparation_revision preparation_files_digest <<EOF
+        $source_identity
+        EOF
+                case "$preparation_revision" in
+                  ""|*[!0-9a-fA-F]*)
+                    printf 'The Git revision was not a deterministic hexadecimal identifier.\n' >&2
+                    exit 78
+                    ;;
+                esac
+                case "$preparation_files_digest" in
+                  ""|*[!0-9a-fA-F]*)
+                    printf 'The source digest was not a deterministic hexadecimal identifier.\n' >&2
+                    exit 78
+                    ;;
+                esac
+                case "''${#preparation_revision}" in
+                  40|64)
+                    ;;
+                  *)
+                  printf 'The Git revision has an unexpected length.\n' >&2
+                  exit 78
+                    ;;
+                esac
+                [ "''${#preparation_files_digest}" -eq 64 ] || {
+                  printf 'The source digest has an unexpected length.\n' >&2
+                  exit 78
+                }
+
+                environment_file_digest="$(${pkgs.coreutils}/bin/sha256sum "$proof_environment_snapshot" | \
+                  ${pkgs.coreutils}/bin/cut -d ' ' -f 1)" || {
+                  printf 'The environment snapshot could not be hashed safely.\n' >&2
+                  exit 78
+                }
+                preparation_runtime_digest="$({
+                  printf 'project-directory\0%s\0' "$preparation_project_directory"
+                  printf 'static-configuration-digest\0%s\0' "$static_configuration_digest"
+                  printf 'proxy-mode\0%s\0' "$proxy_mode"
+                  printf 'environment-file-digest\0%s\0' "$environment_file_digest"
+                  for runtime_setting in "''${required_settings[@]}"; do
+                    runtime_value="''${!runtime_setting}"
+                    runtime_value_digest="$(${pkgs.coreutils}/bin/sha256sum <<<"$runtime_value")"
+                    runtime_value_digest="''${runtime_value_digest%% *}"
+                    printf '%s\0%s\0' "$runtime_setting" "$runtime_value_digest"
+                  done
+                  if [ "$proxy_mode" = disabled ]; then
+                    printf 'SERVICE_PROXY_ATTESTATION\0disabled\0'
+                  fi
+                } | ${pkgs.coreutils}/bin/sha256sum | ${pkgs.coreutils}/bin/cut -d ' ' -f 1)" || {
+                  printf 'The launch configuration could not be hashed safely.\n' >&2
+                  exit 78
+                }
+
+                printf '%s\0%s\0%s\0%s\0%s\0%s' \
+                  "$preparation_project_directory" \
+                  "$LOCAL_CONTROL_PREPARATION_INPUT" \
+                  "$preparation_revision" \
+                  "$preparation_files_digest" \
+                  "$environment_file_digest" \
+                  "$preparation_runtime_digest" |
+                  ${pkgs.coreutils}/bin/sha256sum |
+                  ${pkgs.coreutils}/bin/cut -d ' ' -f 1
+      '';
+    };
+
+  mkPrivatePathGuard =
+    pkgs:
+    let
+      secureFileSystem = mkSecureFileSystem pkgs;
+    in
+    pkgs.writeShellApplication {
+      name = "local-control-private-path";
+      runtimeInputs = [ secureFileSystem ];
+      text = ''
+        set -euo pipefail
+        if [ "$#" -lt 2 ]; then
+          printf 'Usage: local-control-private-path MODE PATH [DESCRIPTION] [FILE_MODE]\n' >&2
+          exit 64
+        fi
+        case "$1" in
+          ensure-directory)
+            [ "$#" -ge 3 ] || exit 64
+            exec ${secureFileSystem}/bin/local-control-secure-files ensure-directory "$2"
+            ;;
+          validate-directory)
+            [ "$#" -ge 3 ] || exit 64
+            exec ${secureFileSystem}/bin/local-control-secure-files validate-directory "$2"
+            ;;
+          validate-file)
+            [ "$#" -eq 4 ] || exit 64
+            exec ${secureFileSystem}/bin/local-control-secure-files validate-file "$2" "$4"
+            ;;
+          *)
+            printf 'The private path guard received an invalid mode.\n' >&2
+            exit 64
+            ;;
+        esac
+      '';
+    };
+
+  mkPreparationGate =
+    pkgs:
+    let
+      environmentSnapshot = mkEnvironmentSnapshot pkgs;
+      preparationProof = mkPreparationProof pkgs;
+      secureFileSystem = mkSecureFileSystem pkgs;
+    in
+    pkgs.writeShellApplication {
+      name = "local-control-service-gate";
+      runtimeInputs = [
+        pkgs.coreutils
+        environmentSnapshot
+        preparationProof
+        secureFileSystem
+      ];
+      text = ''
+        set -euo pipefail
+        export LC_ALL=C
+        if [ "$#" -lt 6 ]; then
+          printf 'Usage: local-control-service-gate ENVIRONMENT_FILE PREPARATION_STAMP STATE_DIRECTORY STATIC_DIGEST PROXY_MODE COMMAND...\n' >&2
+          exit 64
+        fi
+        gate_environment_file="$1"
+        gate_preparation_stamp="$2"
+        gate_state_directory="$3"
+        gate_static_configuration_digest="$4"
+        gate_proxy_mode="$5"
+        shift 5
+        case "$gate_proxy_mode" in
+          enabled|disabled)
+            ;;
+          *)
+            printf 'The service gate received an invalid proxy mode.\n' >&2
+            exit 64
+            ;;
+        esac
+
+        gate_environment_snapshot="$(${pkgs.coreutils}/bin/mktemp "$gate_state_directory/gate-environment.XXXXXX")"
+        if ! ${environmentSnapshot}/bin/local-control-environment-snapshot read \
+          "$gate_environment_file" "$gate_proxy_mode" > "$gate_environment_snapshot"; then
+          ${pkgs.coreutils}/bin/rm -f "$gate_environment_snapshot"
+          printf 'The service environment is missing, unsafe, or invalid.\n' >&2
+          exit 0
+        fi
+
+        gate_preparation_state="$(${preparationProof}/bin/local-control-preparation-proof compute \
+          "$gate_static_configuration_digest" \
+          "$gate_proxy_mode" \
+          "$gate_environment_snapshot")" || {
+          ${pkgs.coreutils}/bin/rm -f "$gate_environment_snapshot"
+          printf 'The service preparation proof is unavailable.\n' >&2
+          exit 0
+        }
+        gate_stamp_value="$(${secureFileSystem}/bin/local-control-secure-files read-file \
+          "$gate_preparation_stamp" 600)" || {
+          ${pkgs.coreutils}/bin/rm -f "$gate_environment_snapshot"
+          printf 'The service preparation stamp is missing or unsafe.\n' >&2
+          exit 0
+        }
+        if [ "$gate_stamp_value" != "$gate_preparation_state" ]; then
+          ${pkgs.coreutils}/bin/rm -f "$gate_environment_snapshot"
+          printf 'The service preparation stamp is stale.\n' >&2
+          exit 0
+        fi
+
+        export LOCAL_CONTROL_ENVIRONMENT_SNAPSHOT="$gate_environment_snapshot"
+        exec "$@"
+      '';
+    };
+
+  mkDatabaseClusterValidator =
+    pkgs:
+    let
+      secureFileSystem = mkSecureFileSystem pkgs;
+    in
+    pkgs.writeShellApplication {
+      name = "local-control-validate-database-cluster";
+      runtimeInputs = [
         pkgs.postgresql_18
+        secureFileSystem
       ];
       text = ''
         set -euo pipefail
         if [ "$#" -ne 1 ]; then
-          printf 'Exactly one PostgreSQL data directory is required.\n' >&2
+          printf 'Exactly one database directory is required.\n' >&2
           exit 64
         fi
-
-        postgres_data_dir="$1"
-        if [ -L "$postgres_data_dir" ] || [ ! -d "$postgres_data_dir" ]; then
-          exit 1
-        fi
-        if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' "$postgres_data_dir" )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
-          exit 1
-        fi
-        postgres_dir_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' "$postgres_data_dir" )"
-        if (( (8#$postgres_dir_mode & 0077) != 0 )); then
-          exit 1
-        fi
-        for postgres_control_file in PG_VERSION postgresql.conf pg_hba.conf pg_ident.conf; do
-          postgres_control_path="$postgres_data_dir/$postgres_control_file"
-          if [ -L "$postgres_control_path" ] || [ ! -f "$postgres_control_path" ]; then
-            exit 1
-          fi
-          if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' "$postgres_control_path" )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
-            exit 1
-          fi
-          postgres_control_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' "$postgres_control_path" )"
-          if (( (8#$postgres_control_mode & 0077) != 0 )); then
-            exit 1
-          fi
-        done
-        for postgres_control_dir in base global pg_wal; do
-          postgres_control_path="$postgres_data_dir/$postgres_control_dir"
-          if [ -L "$postgres_control_path" ] || [ ! -d "$postgres_control_path" ]; then
-            exit 1
-          fi
-          if [ "$( ${pkgs.coreutils}/bin/stat -c '%u' "$postgres_control_path" )" != "$( ${pkgs.coreutils}/bin/id -u )" ]; then
-            exit 1
-          fi
-          postgres_control_mode="$( ${pkgs.coreutils}/bin/stat -c '%a' "$postgres_control_path" )"
-          if (( (8#$postgres_control_mode & 0077) != 0 )); then
-            exit 1
-          fi
-        done
-        postgres_major=""
-        IFS= read -r postgres_major < "$postgres_data_dir/PG_VERSION" || true
-        [ "$postgres_major" = 18 ] || exit 1
-        ${pkgs.postgresql_18}/bin/pg_controldata "$postgres_data_dir" >/dev/null 2>&1
+        ${secureFileSystem}/bin/local-control-secure-files exec-cluster \
+          "$1" 18 ${pkgs.postgresql_18}/bin/pg_controldata . >/dev/null 2>&1
       '';
     };
+in
+{
+  inherit
+    mkEnvironmentSnapshot
+    mkPreparationGate
+    mkPreparationProof
+    mkPrivatePathGuard
+    mkSecureFileSystem
+    mkSourceTreeSnapshot
+    mkDatabaseClusterValidator
+    ;
 }

--- a/lib/local-control/secure-files.c
+++ b/lib/local-control/secure-files.c
@@ -1226,7 +1226,8 @@ static int command_exec_cluster_socket(int argc, char **argv) {
     close(socket_fd);
     return 1;
   }
-  child_argv = calloc((size_t)(argc - 4), sizeof(*child_argv));
+  /* argv[4] and argv[5..argc) require one additional NULL terminator. */
+  child_argv = calloc((size_t)(argc - 3), sizeof(*child_argv));
   if (child_argv == NULL) {
     close(cluster_fd);
     close(socket_fd);

--- a/lib/local-control/secure-files.c
+++ b/lib/local-control/secure-files.c
@@ -1,0 +1,1774 @@
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+
+#ifndef O_DIRECTORY
+#error "O_DIRECTORY is required for descriptor-bound directory operations"
+#endif
+
+#ifndef O_NOFOLLOW
+#error "O_NOFOLLOW is required for descriptor-bound path operations"
+#endif
+
+static void usage(void);
+
+static void fail_message(const char *message) { fprintf(stderr, "%s\n", message); }
+
+static int fail_errno(const char *operation) {
+  fprintf(stderr, "%s: %s\n", operation, strerror(errno));
+  return 1;
+}
+
+static int is_private_mode(mode_t mode) { return (mode & 0077) == 0; }
+
+static int is_owned_by_user(const struct stat *status) { return status->st_uid == geteuid(); }
+
+static int parse_mode(const char *text, mode_t *mode) {
+  char *end = NULL;
+  unsigned long parsed;
+
+  if (text == NULL || *text == '\0') {
+    return 0;
+  }
+  errno = 0;
+  parsed = strtoul(text, &end, 8);
+  if (errno != 0 || end == text || *end != '\0' || parsed > 07777) {
+    return 0;
+  }
+  *mode = (mode_t)parsed;
+  return 1;
+}
+
+static int verify_status(const struct stat *status, int directory, const char *mode_text) {
+  mode_t expected_mode = 0;
+
+  if (directory) {
+    if (!S_ISDIR(status->st_mode)) {
+      fail_message("Expected a real directory.");
+      return 0;
+    }
+  } else if (!S_ISREG(status->st_mode)) {
+    fail_message("Expected a regular file.");
+    return 0;
+  }
+  if (!is_owned_by_user(status)) {
+    fail_message("Path is not owned by the current user.");
+    return 0;
+  }
+  if (mode_text != NULL && strcmp(mode_text, "private") == 0) {
+    if (!is_private_mode(status->st_mode)) {
+      fail_message("Path is accessible to group or others.");
+      return 0;
+    }
+  } else {
+    if (!parse_mode(mode_text, &expected_mode) || (status->st_mode & 07777) != expected_mode) {
+      fail_message("Path has an unexpected mode.");
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int component_is_dot(const char *component, size_t length) {
+  return (length == 1 && component[0] == '.') ||
+        (length == 2 && component[0] == '.' && component[1] == '.');
+}
+
+static int open_trusted_path(const char *path, int final_flags) {
+  const char *cursor;
+  int directory_fd;
+
+  if (path == NULL || *path == '\0') {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (strcmp(path, ".") == 0) {
+    return open(".", O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW | final_flags);
+  }
+
+  directory_fd = open(path[0] == '/' ? "/" : ".",
+                      O_RDONLY | O_NONBLOCK | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+  if (directory_fd < 0) {
+    return -1;
+  }
+
+  cursor = path;
+  while (*cursor == '/') {
+    cursor++;
+  }
+  if (*cursor == '\0') {
+    return directory_fd;
+  }
+
+  for (;;) {
+    const char *separator = cursor;
+    size_t component_length;
+    int is_final;
+    int next_fd;
+    char *component;
+    int flags = O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW;
+
+    while (*separator != '\0' && *separator != '/') {
+      separator++;
+    }
+    component_length = (size_t)(separator - cursor);
+    if (component_length == 0 || component_is_dot(cursor, component_length)) {
+      close(directory_fd);
+      errno = EINVAL;
+      return -1;
+    }
+    component = malloc(component_length + 1);
+    if (component == NULL) {
+      close(directory_fd);
+      errno = ENOMEM;
+      return -1;
+    }
+    memcpy(component, cursor, component_length);
+    component[component_length] = '\0';
+
+    cursor = separator;
+    while (*cursor == '/') {
+      cursor++;
+    }
+    is_final = *cursor == '\0';
+    if (!is_final) {
+      flags |= O_DIRECTORY;
+    } else {
+      flags |= final_flags;
+    }
+
+    next_fd = openat(directory_fd, component, flags);
+    free(component);
+    close(directory_fd);
+    if (next_fd < 0) {
+      return -1;
+    }
+    if (is_final) {
+      return next_fd;
+    }
+    directory_fd = next_fd;
+  }
+}
+
+static int valid_leaf_name(const char *name) {
+  return name != NULL && *name != '\0' && strchr(name, '/') == NULL &&
+    !component_is_dot(name, strlen(name));
+}
+
+static int open_trusted_parent(const char *path, char **name_out) {
+  const char *separator;
+  char *parent_path;
+  char *name;
+  size_t parent_length;
+  int parent_fd;
+
+  if (path == NULL || *path == '\0') {
+    errno = EINVAL;
+    return -1;
+  }
+  separator = strrchr(path, '/');
+  if (separator == NULL) {
+    parent_path = strdup(".");
+    name = strdup(path);
+  } else {
+    parent_length = (size_t)(separator - path);
+    if (parent_length == 0) {
+      parent_path = strdup("/");
+    } else {
+      parent_path = malloc(parent_length + 1);
+      if (parent_path != NULL) {
+        memcpy(parent_path, path, parent_length);
+        parent_path[parent_length] = '\0';
+      }
+    }
+    name = strdup(separator + 1);
+  }
+  if (parent_path == NULL || name == NULL || !valid_leaf_name(name)) {
+    free(parent_path);
+    free(name);
+    errno = EINVAL;
+    return -1;
+  }
+  parent_fd = open_trusted_path(parent_path, O_DIRECTORY);
+  free(parent_path);
+  if (parent_fd < 0) {
+    free(name);
+    return -1;
+  }
+  *name_out = name;
+  return parent_fd;
+}
+
+static int open_child(int directory_fd, const char *name, int directory) {
+  int flags = O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW;
+  if (directory) {
+    flags |= O_DIRECTORY;
+  }
+  return openat(directory_fd, name, flags);
+}
+
+static int stat_matches(const struct stat *before, const struct stat *after) {
+  if (before->st_dev != after->st_dev || before->st_ino != after->st_ino ||
+      before->st_mode != after->st_mode || before->st_uid != after->st_uid ||
+      before->st_gid != after->st_gid || before->st_nlink != after->st_nlink ||
+      before->st_size != after->st_size) {
+    return 0;
+  }
+#if defined(__APPLE__)
+  return before->st_mtimespec.tv_sec == after->st_mtimespec.tv_sec &&
+        before->st_mtimespec.tv_nsec == after->st_mtimespec.tv_nsec &&
+        before->st_ctimespec.tv_sec == after->st_ctimespec.tv_sec &&
+        before->st_ctimespec.tv_nsec == after->st_ctimespec.tv_nsec;
+#else
+  return before->st_mtim.tv_sec == after->st_mtim.tv_sec &&
+        before->st_mtim.tv_nsec == after->st_mtim.tv_nsec &&
+        before->st_ctim.tv_sec == after->st_ctim.tv_sec &&
+        before->st_ctim.tv_nsec == after->st_ctim.tv_nsec;
+#endif
+}
+
+static int verify_fd(int fd, int directory, const char *mode_text, struct stat *status) {
+  if (fstat(fd, status) < 0) {
+    return fail_errno("fstat");
+  }
+  return verify_status(status, directory, mode_text) ? 0 : 1;
+}
+
+static int command_validate_file(const char *path, const char *mode_text, int report_state) {
+  struct stat status;
+  int fd = open_trusted_path(path, 0);
+  if (fd < 0) {
+    if (errno == ENOENT && report_state) {
+      puts("missing");
+      return 0;
+    }
+    return fail_errno("openat");
+  }
+  if (verify_fd(fd, 0, mode_text, &status) != 0) {
+    close(fd);
+    return 1;
+  }
+  close(fd);
+  if (report_state) {
+    puts("present");
+  }
+  return 0;
+}
+
+static int command_repair_file_mode(const char *path, const char *mode_text) {
+  mode_t mode;
+  struct stat before;
+  struct stat after;
+  int fd;
+
+  if (!parse_mode(mode_text, &mode)) {
+    fail_message("The requested file mode is invalid.");
+    return 64;
+  }
+  fd = open_trusted_path(path, O_RDWR);
+  if (fd < 0) {
+    if (errno == ENOENT) {
+      puts("missing");
+      return 0;
+    }
+    return fail_errno("openat");
+  }
+  if (fstat(fd, &before) < 0) {
+    int result = fail_errno("fstat");
+    close(fd);
+    return result;
+  }
+  if (!S_ISREG(before.st_mode)) {
+    close(fd);
+    fail_message("Expected a real regular file.");
+    return 1;
+  }
+  if (!is_owned_by_user(&before)) {
+    close(fd);
+    fail_message("Path is not owned by the current user.");
+    return 1;
+  }
+  if (fchmod(fd, mode) < 0) {
+    int result = fail_errno("fchmod");
+    close(fd);
+    return result;
+  }
+  if (fstat(fd, &after) < 0) {
+    int result = fail_errno("fstat");
+    close(fd);
+    return result;
+  }
+  if (before.st_dev != after.st_dev || before.st_ino != after.st_ino ||
+      before.st_uid != after.st_uid || before.st_gid != after.st_gid ||
+      before.st_nlink != after.st_nlink ||
+      (after.st_mode & 07777) != mode) {
+    close(fd);
+    fail_message("The file changed while its mode was being repaired.");
+    return 1;
+  }
+  close(fd);
+  puts("present");
+  return 0;
+}
+
+static int command_validate_directory(const char *path) {
+  struct stat status;
+  int fd = open_trusted_path(path, O_DIRECTORY);
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  if (verify_fd(fd, 1, "private", &status) != 0) {
+    close(fd);
+    return 1;
+  }
+  close(fd);
+  return 0;
+}
+
+static int command_validate_source_directory(const char *path) {
+  struct stat status;
+  int fd = open_trusted_path(path, O_DIRECTORY);
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  if (fstat(fd, &status) < 0) {
+    int result = fail_errno("fstat");
+    close(fd);
+    return result;
+  }
+  if (!S_ISDIR(status.st_mode) || !is_owned_by_user(&status)) {
+    close(fd);
+    fail_message("Source directory is not an owned real directory.");
+    return 1;
+  }
+  close(fd);
+  return 0;
+}
+
+static int command_ensure_directory(const char *path) {
+  const char *cursor;
+  int directory_fd;
+
+  if (path == NULL || *path == '\0') {
+    errno = EINVAL;
+    return fail_errno("invalid directory path");
+  }
+  directory_fd = open(path[0] == '/' ? "/" : ".", O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+  if (directory_fd < 0) {
+    return fail_errno("openat");
+  }
+  cursor = path;
+  while (*cursor == '/') {
+    cursor++;
+  }
+  while (*cursor != '\0') {
+    const char *separator = cursor;
+    size_t component_length;
+    int next_fd;
+    char *component;
+
+    while (*separator != '\0' && *separator != '/') {
+      separator++;
+    }
+    component_length = (size_t)(separator - cursor);
+    if (component_length == 0 || component_is_dot(cursor, component_length)) {
+      close(directory_fd);
+      errno = EINVAL;
+      return fail_errno("invalid directory path");
+    }
+    component = malloc(component_length + 1);
+    if (component == NULL) {
+      close(directory_fd);
+      errno = ENOMEM;
+      return fail_errno("malloc");
+    }
+    memcpy(component, cursor, component_length);
+    component[component_length] = '\0';
+    cursor = separator;
+    while (*cursor == '/') {
+      cursor++;
+    }
+
+    next_fd = openat(directory_fd, component, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (next_fd < 0 && errno == ENOENT) {
+      if (mkdirat(directory_fd, component, 0700) < 0 && errno != EEXIST) {
+        int saved_errno = errno;
+        free(component);
+        close(directory_fd);
+        errno = saved_errno;
+        return fail_errno("mkdirat");
+      }
+      next_fd = openat(directory_fd, component, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    }
+    free(component);
+    close(directory_fd);
+    if (next_fd < 0) {
+      return fail_errno("openat");
+    }
+    directory_fd = next_fd;
+  }
+
+  {
+    struct stat status;
+    if (verify_fd(directory_fd, 1, "private", &status) != 0) {
+      close(directory_fd);
+      return 1;
+    }
+    if (fchmod(directory_fd, 0700) < 0) {
+      int result = fail_errno("fchmod");
+      close(directory_fd);
+      return result;
+    }
+  }
+  close(directory_fd);
+  return 0;
+}
+
+static int command_directory_empty(const char *path) {
+  int fd = open_trusted_path(path, O_DIRECTORY);
+  int scan_fd;
+  DIR *directory;
+  struct dirent *entry;
+  int result = 0;
+
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  if (verify_fd(fd, 1, "private", &(struct stat){0}) != 0) {
+    close(fd);
+    return 1;
+  }
+  scan_fd = dup(fd);
+  if (scan_fd < 0) {
+    close(fd);
+    return fail_errno("dup");
+  }
+  directory = fdopendir(scan_fd);
+  if (directory == NULL) {
+    close(scan_fd);
+    close(fd);
+    return fail_errno("fdopendir");
+  }
+  errno = 0;
+  while ((entry = readdir(directory)) != NULL) {
+    if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0) {
+      result = 1;
+      break;
+    }
+  }
+  if (errno != 0) {
+    result = 1;
+  }
+  closedir(directory);
+  close(fd);
+  return result;
+}
+
+static int directory_fd_is_empty(int fd) {
+  int scan_fd = dup(fd);
+  DIR *directory;
+  struct dirent *entry;
+  int result = 1;
+
+  if (scan_fd < 0) {
+    return -1;
+  }
+  directory = fdopendir(scan_fd);
+  if (directory == NULL) {
+    close(scan_fd);
+    return -1;
+  }
+  errno = 0;
+  while ((entry = readdir(directory)) != NULL) {
+    if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0) {
+      result = 0;
+      break;
+    }
+  }
+  if (errno != 0) {
+    result = -1;
+  }
+  closedir(directory);
+  return result;
+}
+
+static int read_fd_to_stdout(int fd, const struct stat *before) {
+  char buffer[65536];
+  ssize_t count;
+  off_t total = 0;
+  struct stat after;
+
+  for (;;) {
+    count = read(fd, buffer, sizeof(buffer));
+    if (count < 0) {
+      return fail_errno("read");
+    }
+    if (count == 0) {
+      break;
+    }
+    if (fwrite(buffer, 1, (size_t)count, stdout) != (size_t)count) {
+      return fail_errno("write");
+    }
+    total += count;
+  }
+  if (fstat(fd, &after) < 0) {
+    return fail_errno("fstat");
+  }
+  if (total != before->st_size || !stat_matches(before, &after)) {
+    fail_message("File changed while it was being read.");
+    return 1;
+  }
+  return 0;
+}
+
+static int command_read_file(const char *path, const char *mode_text) {
+  struct stat status;
+  int fd = open_trusted_path(path, 0);
+  int result;
+
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  if (verify_fd(fd, 0, mode_text, &status) != 0) {
+    close(fd);
+    return 1;
+  }
+  result = read_fd_to_stdout(fd, &status);
+  close(fd);
+  return result;
+}
+
+static int write_stdin_to_fd(int fd) {
+  unsigned char buffer[65536];
+  ssize_t count;
+
+  for (;;) {
+    count = read(STDIN_FILENO, buffer, sizeof(buffer));
+    if (count < 0) {
+      return fail_errno("read");
+    }
+    if (count == 0) {
+      return 0;
+    }
+    {
+      ssize_t written = 0;
+      while (written < count) {
+        ssize_t result = write(fd, buffer + written, (size_t)(count - written));
+        if (result < 0) {
+          return fail_errno("write");
+        }
+        written += result;
+      }
+    }
+  }
+}
+
+static int command_create_file(const char *path, const char *mode_text) {
+  char *name = NULL;
+  mode_t mode;
+  int parent_fd;
+  int fd;
+  struct stat status;
+  int result = 1;
+
+  if (!parse_mode(mode_text, &mode)) {
+    fail_message("The requested file mode is invalid.");
+    return 64;
+  }
+  parent_fd = open_trusted_parent(path, &name);
+  if (parent_fd < 0) {
+    return fail_errno("openat");
+  }
+  fd = openat(parent_fd, name, O_WRONLY | O_CLOEXEC | O_NOFOLLOW | O_CREAT | O_EXCL, mode);
+  if (fd < 0) {
+    result = fail_errno("openat");
+    close(parent_fd);
+    free(name);
+    return result;
+  }
+  if (fchmod(fd, mode) < 0 || fstat(fd, &status) < 0 || !verify_status(&status, 0, mode_text)) {
+    if (errno != 0) {
+      result = fail_errno("create file");
+    }
+    close(fd);
+    unlinkat(parent_fd, name, 0);
+    close(parent_fd);
+    free(name);
+    return result;
+  }
+  if (write_stdin_to_fd(fd) != 0 || fsync(fd) < 0) {
+    result = errno == 0 ? 1 : fail_errno("create file");
+    close(fd);
+    unlinkat(parent_fd, name, 0);
+    close(parent_fd);
+    free(name);
+    return result;
+  }
+  if (close(fd) < 0) {
+    result = fail_errno("close");
+    unlinkat(parent_fd, name, 0);
+    close(parent_fd);
+    free(name);
+    return result;
+  }
+  close(parent_fd);
+  free(name);
+  return 0;
+}
+
+static int command_atomic_write(const char *path, const char *mode_text) {
+  char *name = NULL;
+  mode_t mode;
+  int parent_fd;
+  int target_fd;
+  int temporary_fd = -1;
+  char temporary_name[NAME_MAX];
+  struct stat status;
+  unsigned long attempt;
+  int result;
+
+  if (!parse_mode(mode_text, &mode)) {
+    fail_message("The requested file mode is invalid.");
+    return 64;
+  }
+  parent_fd = open_trusted_parent(path, &name);
+  if (parent_fd < 0) {
+    return fail_errno("openat");
+  }
+  target_fd = openat(parent_fd, name, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+  if (target_fd >= 0) {
+    if (verify_fd(target_fd, 0, mode_text, &status) != 0) {
+      close(target_fd);
+      close(parent_fd);
+      free(name);
+      return 1;
+    }
+    close(target_fd);
+  } else if (errno != ENOENT) {
+    result = fail_errno("openat");
+    close(parent_fd);
+    free(name);
+    return result;
+  }
+
+  for (attempt = 0; attempt < 1000; attempt++) {
+    int written =
+      snprintf(temporary_name, sizeof(temporary_name), ".local-control.%ld.%lu", (long)getpid(), attempt);
+    if (written < 0 || (size_t)written >= sizeof(temporary_name)) {
+      close(parent_fd);
+      free(name);
+      errno = ENAMETOOLONG;
+      return fail_errno("temporary file");
+    }
+    temporary_fd = openat(parent_fd, temporary_name,
+                          O_WRONLY | O_CLOEXEC | O_NOFOLLOW | O_CREAT | O_EXCL, mode);
+    if (temporary_fd >= 0) {
+      break;
+    }
+    if (errno != EEXIST) {
+      result = fail_errno("openat");
+      close(parent_fd);
+      free(name);
+      return result;
+    }
+  }
+  if (temporary_fd < 0) {
+    close(parent_fd);
+    free(name);
+    errno = EEXIST;
+    return fail_errno("temporary file");
+  }
+  if (fchmod(temporary_fd, mode) < 0 || write_stdin_to_fd(temporary_fd) != 0 || fsync(temporary_fd) < 0) {
+    result = errno == 0 ? 1 : fail_errno("atomic write");
+    close(temporary_fd);
+    unlinkat(parent_fd, temporary_name, 0);
+    close(parent_fd);
+    free(name);
+    return result;
+  }
+  if (close(temporary_fd) < 0 || renameat(parent_fd, temporary_name, parent_fd, name) < 0 ||
+      fsync(parent_fd) < 0) {
+    result = fail_errno("atomic write");
+    unlinkat(parent_fd, temporary_name, 0);
+    close(parent_fd);
+    free(name);
+    return result;
+  }
+  close(parent_fd);
+  free(name);
+  return 0;
+}
+
+static int validate_cluster_child(int directory_fd, const char *name, int directory) {
+  struct stat status;
+  int fd = open_child(directory_fd, name, directory);
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  if (verify_fd(fd, directory, "private", &status) != 0) {
+    close(fd);
+    return 1;
+  }
+  close(fd);
+  return 0;
+}
+
+static int open_exec_directory(const char *path, int private_directory) {
+  int fd = open_trusted_path(path, O_DIRECTORY);
+  struct stat status;
+
+  if (fd < 0) {
+    return -1;
+  }
+  if (private_directory) {
+    if (verify_fd(fd, 1, "private", &status) != 0) {
+      close(fd);
+      return -1;
+    }
+  } else if (fstat(fd, &status) < 0 || !S_ISDIR(status.st_mode) || !is_owned_by_user(&status)) {
+    close(fd);
+    fail_message("Source directory is not an owned real directory.");
+    return -1;
+  }
+  return fd;
+}
+
+static int exec_with_directory(const char *path, int private_directory, const char *executable,
+    int argument_count, char **arguments) {
+  int fd = open_exec_directory(path, private_directory);
+  char **child_argv;
+  int result;
+
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  child_argv = calloc((size_t)argument_count + 2, sizeof(*child_argv));
+  if (child_argv == NULL) {
+    close(fd);
+    errno = ENOMEM;
+    return fail_errno("calloc");
+  }
+  child_argv[0] = (char *)executable;
+  for (int index = 0; index < argument_count; index++) {
+    child_argv[index + 1] = arguments[index];
+  }
+  if (fchdir(fd) < 0) {
+    result = fail_errno("fchdir");
+    free(child_argv);
+    close(fd);
+    return result;
+  }
+  execv(executable, child_argv);
+  result = fail_errno("execv");
+  free(child_argv);
+  close(fd);
+  return result;
+}
+
+static int exec_with_empty_directory(const char *path, const char *executable, int argument_count,
+    char **arguments) {
+  int fd = open_exec_directory(path, 1);
+  char **child_argv;
+  int empty;
+  int result;
+
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  empty = directory_fd_is_empty(fd);
+  if (empty < 0) {
+    result = fail_errno("readdir");
+    close(fd);
+    return result;
+  }
+  if (empty == 0) {
+    fail_message("The directory is not empty.");
+    close(fd);
+    return 1;
+  }
+  child_argv = calloc((size_t)argument_count + 2, sizeof(*child_argv));
+  if (child_argv == NULL) {
+    close(fd);
+    errno = ENOMEM;
+    return fail_errno("calloc");
+  }
+  child_argv[0] = (char *)executable;
+  for (int index = 0; index < argument_count; index++) {
+    child_argv[index + 1] = arguments[index];
+  }
+  if (fchdir(fd) < 0) {
+    result = fail_errno("fchdir");
+    free(child_argv);
+    close(fd);
+    return result;
+  }
+  execv(executable, child_argv);
+  result = fail_errno("execv");
+  free(child_argv);
+  close(fd);
+  return result;
+}
+
+struct file_mapping {
+  char *name;
+  int fd;
+};
+
+static void close_file_mappings(struct file_mapping *mappings, size_t count) {
+  for (size_t index = 0; index < count; index++) {
+    close(mappings[index].fd);
+    free(mappings[index].name);
+  }
+  free(mappings);
+}
+
+static int find_file_mapping(const struct file_mapping *mappings, size_t count, const char *name) {
+  for (size_t index = 0; index < count; index++) {
+    if (strcmp(mappings[index].name, name) == 0) {
+      return (int)index;
+    }
+  }
+  return -1;
+}
+
+static int make_inheritable(int fd) {
+  int flags = fcntl(fd, F_GETFD);
+  if (flags < 0 || fcntl(fd, F_SETFD, flags & ~FD_CLOEXEC) < 0) {
+    return fail_errno("fcntl");
+  }
+  return 0;
+}
+
+static int resolve_fd_path(int fd, char **path_out) {
+  char path[PATH_MAX];
+
+  if (path_out == NULL) {
+    errno = EINVAL;
+    return fail_errno("resolve fd path");
+  }
+
+#if defined(__APPLE__)
+  memset(path, 0, sizeof(path));
+  if (fcntl(fd, F_GETPATH, path) < 0) {
+    return fail_errno("fcntl");
+  }
+#else
+  char proc_path[64];
+  int proc_path_length = snprintf(proc_path, sizeof(proc_path), "/proc/self/fd/%d", fd);
+  if (proc_path_length < 0 || (size_t)proc_path_length >= sizeof(proc_path)) {
+    errno = EOVERFLOW;
+    return fail_errno("format fd path");
+  }
+  ssize_t path_length = readlink(proc_path, path, sizeof(path) - 1);
+  if (path_length < 0) {
+    return fail_errno("readlink");
+  }
+  if ((size_t)path_length >= sizeof(path) - 1) {
+    errno = ENAMETOOLONG;
+    return fail_errno("readlink");
+  }
+  path[path_length] = '\0';
+#endif
+
+  if (path[0] != '/') {
+    errno = EINVAL;
+    return fail_errno("resolve fd path");
+  }
+  *path_out = strdup(path);
+  if (*path_out == NULL) {
+    errno = ENOMEM;
+    return fail_errno("strdup");
+  }
+  return 0;
+}
+
+static int open_mapped_file(int directory_fd, const char *name, const char *mode_text,
+                            const char *kind, int *fd_out) {
+  int flags;
+  mode_t mode;
+  int fd;
+  struct stat status;
+
+  if (!valid_leaf_name(name) || !parse_mode(mode_text, &mode)) {
+    fail_message("The mapped file specification is invalid.");
+    return 64;
+  }
+  if (strcmp(kind, "create") == 0) {
+    flags = O_RDWR | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW | O_CREAT | O_EXCL;
+    fd = openat(directory_fd, name, flags, mode);
+    if (fd >= 0 && fchmod(fd, mode) < 0) {
+      int saved_errno = errno;
+      close(fd);
+      unlinkat(directory_fd, name, 0);
+      errno = saved_errno;
+      return fail_errno("fchmod");
+    }
+  } else if (strcmp(kind, "update") == 0) {
+    fd = openat(directory_fd, name, O_RDWR | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW);
+  } else if (strcmp(kind, "read") == 0) {
+    fd = openat(directory_fd, name, O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW);
+  } else {
+    fail_message("The mapped file mode is invalid.");
+    return 64;
+  }
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  if (verify_fd(fd, 0, mode_text, &status) != 0 || make_inheritable(fd) != 0) {
+    close(fd);
+    if (strcmp(kind, "create") == 0) {
+      unlinkat(directory_fd, name, 0);
+    }
+    return 1;
+  }
+  *fd_out = fd;
+  return 0;
+}
+
+static int command_exec_files(int argc, char **argv) {
+  int directory_fd;
+  struct file_mapping *mappings = NULL;
+  size_t mapping_count = 0;
+  size_t mapping_capacity = 0;
+  int separator = -1;
+  char **child_argv = NULL;
+  int result;
+
+  if (argc < 5) {
+    usage();
+    return 64;
+  }
+  directory_fd = open_exec_directory(argv[1], 1);
+  if (directory_fd < 0) {
+    return fail_errno("openat");
+  }
+  for (int index = 3; index < argc; index++) {
+    if (strcmp(argv[index], "--") == 0) {
+      separator = index;
+      break;
+    }
+    if (index + 3 >= argc ||
+        (strcmp(argv[index], "--create") != 0 && strcmp(argv[index], "--update") != 0 &&
+        strcmp(argv[index], "--read") != 0)) {
+      fail_message("The mapped file command is malformed.");
+      close(directory_fd);
+      return 64;
+    }
+    if (mapping_count == mapping_capacity) {
+      size_t new_capacity = mapping_capacity == 0 ? 4 : mapping_capacity * 2;
+      struct file_mapping *new_mappings = realloc(mappings, new_capacity * sizeof(*new_mappings));
+      if (new_mappings == NULL) {
+        close(directory_fd);
+        close_file_mappings(mappings, mapping_count);
+        errno = ENOMEM;
+        return fail_errno("realloc");
+      }
+      mappings = new_mappings;
+      mapping_capacity = new_capacity;
+    }
+    mappings[mapping_count].name = strdup(argv[index + 1]);
+    if (mappings[mapping_count].name == NULL) {
+      close(directory_fd);
+      close_file_mappings(mappings, mapping_count);
+      errno = ENOMEM;
+      return fail_errno("strdup");
+    }
+    if (find_file_mapping(mappings, mapping_count, mappings[mapping_count].name) >= 0 ||
+        open_mapped_file(directory_fd, argv[index + 1], argv[index + 2], argv[index] + 2,
+        &mappings[mapping_count].fd) != 0) {
+      free(mappings[mapping_count].name);
+      mappings[mapping_count].name = NULL;
+      close(directory_fd);
+      close_file_mappings(mappings, mapping_count);
+      return 1;
+    }
+    mapping_count++;
+    index += 2;
+  }
+  if (separator < 0 || separator + 1 >= argc) {
+    fail_message("The mapped file command is missing its executable arguments.");
+    close(directory_fd);
+    close_file_mappings(mappings, mapping_count);
+    return 64;
+  }
+  child_argv = calloc((size_t)(argc - separator + 1), sizeof(*child_argv));
+  if (child_argv == NULL) {
+    close(directory_fd);
+    close_file_mappings(mappings, mapping_count);
+    errno = ENOMEM;
+    return fail_errno("calloc");
+  }
+  child_argv[0] = argv[2];
+  for (int index = separator + 1; index < argc; index++) {
+    const char *argument = argv[index];
+    char *replacement = NULL;
+    if (argument[0] == '@' && argument[strlen(argument) - 1] == '@') {
+      size_t name_length = strlen(argument) - 2;
+      char *name = strndup(argument + 1, name_length);
+      int mapping_index = name == NULL ? -1 : find_file_mapping(mappings, mapping_count, name);
+      free(name);
+      if (mapping_index < 0) {
+        fail_message("The mapped file placeholder is unknown.");
+        free(child_argv);
+        close(directory_fd);
+        close_file_mappings(mappings, mapping_count);
+        return 64;
+      }
+      if (asprintf(&replacement, "/dev/fd/%d", mappings[mapping_index].fd) < 0) {
+        free(child_argv);
+        close(directory_fd);
+        close_file_mappings(mappings, mapping_count);
+        errno = ENOMEM;
+        return fail_errno("asprintf");
+      }
+      child_argv[index - separator] = replacement;
+    } else {
+      child_argv[index - separator] = argv[index];
+    }
+  }
+  if (fchdir(directory_fd) < 0) {
+    result = fail_errno("fchdir");
+    free(child_argv);
+    close(directory_fd);
+    close_file_mappings(mappings, mapping_count);
+    return result;
+  }
+  execv(argv[2], child_argv);
+  result = fail_errno("execv");
+  for (int index = 1; index < argc - separator; index++) {
+    if (child_argv[index] != argv[separator + index]) {
+      free(child_argv[index]);
+    }
+  }
+  free(child_argv);
+  close(directory_fd);
+  close_file_mappings(mappings, mapping_count);
+  return result;
+}
+
+static int command_exec_proxy(int argc, char **argv) {
+  char *child_argv[argc - 2];
+  int directory_fd;
+  const char *names[] = {"ca.crt", "server.crt", "server.key"};
+  const char *modes[] = {"644", "644", "600"};
+  const char *variables[] = {"LOCAL_CONTROL_PROXY_CA", "LOCAL_CONTROL_PROXY_CERT",
+    "LOCAL_CONTROL_PROXY_KEY"};
+  int file_fds[3];
+
+  if (argc < 4) {
+    usage();
+    return 64;
+  }
+  directory_fd = open_exec_directory(argv[1], 1);
+  if (directory_fd < 0) {
+    return fail_errno("openat");
+  }
+  for (size_t index = 0; index < 3; index++) {
+    if (open_mapped_file(directory_fd, names[index], modes[index], "read", &file_fds[index]) != 0) {
+      close(directory_fd);
+      for (size_t cleanup = 0; cleanup < index; cleanup++) {
+        close(file_fds[cleanup]);
+      }
+      return 1;
+    }
+    char *fd_path = NULL;
+    if (asprintf(&fd_path, "/dev/fd/%d", file_fds[index]) < 0 ||
+        setenv(variables[index], fd_path, 1) < 0) {
+      free(fd_path);
+      close(directory_fd);
+      for (size_t cleanup = 0; cleanup <= index; cleanup++) {
+        close(file_fds[cleanup]);
+      }
+      return fail_errno("setenv");
+    }
+    free(fd_path);
+  }
+  child_argv[0] = argv[2];
+  for (int index = 3; index < argc; index++) {
+    child_argv[index - 2] = argv[index];
+  }
+  child_argv[argc - 2] = NULL;
+  if (fchdir(directory_fd) < 0) {
+    int result = fail_errno("fchdir");
+    close(directory_fd);
+    return result;
+  }
+  execv(argv[2], child_argv);
+  return fail_errno("execv");
+}
+
+static int validate_cluster_fd(int fd, const char *version) {
+  char contents[128];
+  ssize_t count;
+
+  if (verify_fd(fd, 1, "private", &(struct stat){0}) != 0) {
+    return 1;
+  }
+  {
+    const char *files[] = {"PG_VERSION", "postgresql.conf", "pg_hba.conf", "pg_ident.conf"};
+    const char *directories[] = {"base", "global", "pg_wal"};
+    size_t index;
+    for (index = 0; index < sizeof(files) / sizeof(files[0]); index++) {
+      if (validate_cluster_child(fd, files[index], 0) != 0) {
+        return 1;
+      }
+    }
+    for (index = 0; index < sizeof(directories) / sizeof(directories[0]); index++) {
+      if (validate_cluster_child(fd, directories[index], 1) != 0) {
+        return 1;
+      }
+    }
+  }
+
+  {
+    int version_fd = open_child(fd, "PG_VERSION", 0);
+    if (version_fd < 0) {
+      return fail_errno("openat");
+    }
+    count = read(version_fd, contents, sizeof(contents) - 1);
+    if (count < 0) {
+      int result = fail_errno("read");
+      close(version_fd);
+      return result;
+    }
+    contents[count] = '\0';
+    if (strcmp(contents, version) != 0 && (count < 1 || contents[count - 1] != '\n' ||
+                                          strncmp(contents, version, (size_t)count - 1) != 0)) {
+      close(version_fd);
+      fail_message("The directory has an incompatible version marker.");
+      return 1;
+    }
+    close(version_fd);
+  }
+  return 0;
+}
+
+static int command_validate_cluster(const char *path, const char *version) {
+  int fd = open_trusted_path(path, O_DIRECTORY);
+  int result;
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  result = validate_cluster_fd(fd, version);
+  close(fd);
+  return result;
+}
+
+static int command_exec_cluster(int argc, char **argv) {
+  int fd;
+
+  if (argc < 5) {
+    usage();
+    return 64;
+  }
+  fd = open_trusted_path(argv[1], O_DIRECTORY);
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  if (validate_cluster_fd(fd, argv[2]) != 0) {
+    close(fd);
+    return 1;
+  }
+  if (fchdir(fd) < 0) {
+    int result = fail_errno("fchdir");
+    close(fd);
+    return result;
+  }
+  if (execv(argv[3], &argv[3]) < 0) {
+    return fail_errno("execv");
+  }
+  return 1;
+}
+
+static int command_exec_cluster_socket(int argc, char **argv) {
+  int cluster_fd;
+  int socket_fd;
+  struct stat socket_status;
+  char *socket_path = NULL;
+  char **child_argv;
+  int result;
+
+  if (argc < 6) {
+    usage();
+    return 64;
+  }
+  cluster_fd = open_trusted_path(argv[1], O_DIRECTORY);
+  if (cluster_fd < 0) {
+    return fail_errno("openat");
+  }
+  if (validate_cluster_fd(cluster_fd, argv[2]) != 0) {
+    close(cluster_fd);
+    return 1;
+  }
+  socket_fd = open_trusted_path(argv[3], O_DIRECTORY);
+  if (socket_fd < 0) {
+    close(cluster_fd);
+    return fail_errno("openat");
+  }
+  if (verify_fd(socket_fd, 1, "private", &socket_status) != 0 ||
+      resolve_fd_path(socket_fd, &socket_path) != 0) {
+    close(cluster_fd);
+    close(socket_fd);
+    return 1;
+  }
+  child_argv = calloc((size_t)(argc - 4), sizeof(*child_argv));
+  if (child_argv == NULL) {
+    close(cluster_fd);
+    close(socket_fd);
+    free(socket_path);
+    errno = ENOMEM;
+    return fail_errno("calloc");
+  }
+  child_argv[0] = argv[4];
+  for (int index = 5; index < argc; index++) {
+    if (strcmp(argv[index], "@socket@") == 0) {
+      child_argv[index - 4] = strdup(socket_path);
+      if (child_argv[index - 4] == NULL) {
+        free(child_argv);
+        close(cluster_fd);
+        close(socket_fd);
+        free(socket_path);
+        errno = ENOMEM;
+        return fail_errno("strdup");
+      }
+    } else {
+      child_argv[index - 4] = argv[index];
+    }
+  }
+  if (fchdir(cluster_fd) < 0) {
+    result = fail_errno("fchdir");
+    for (int index = 1; index < argc - 4; index++) {
+      if (child_argv[index] != argv[index + 4]) {
+        free(child_argv[index]);
+      }
+    }
+    free(child_argv);
+    close(cluster_fd);
+    close(socket_fd);
+    free(socket_path);
+    return result;
+  }
+  execv(argv[4], child_argv);
+  result = fail_errno("execv");
+  for (int index = 1; index < argc - 4; index++) {
+    if (child_argv[index] != argv[index + 4]) {
+      free(child_argv[index]);
+    }
+  }
+  free(child_argv);
+  close(cluster_fd);
+  close(socket_fd);
+  free(socket_path);
+  return result;
+}
+
+static int command_cluster_state(const char *path, const char *version) {
+  int fd = open_trusted_path(path, O_DIRECTORY);
+  int marker_fd;
+  int empty;
+  char contents[128];
+  ssize_t count;
+
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  if (verify_fd(fd, 1, "private", &(struct stat){0}) != 0) {
+    close(fd);
+    return 1;
+  }
+  marker_fd = open_child(fd, "PG_VERSION", 0);
+  if (marker_fd < 0 && errno == ENOENT) {
+    empty = directory_fd_is_empty(fd);
+    close(fd);
+    if (empty < 0) {
+      return fail_errno("readdir");
+    }
+    if (empty == 1) {
+      puts("missing");
+      return 0;
+    }
+    fail_message("The database directory is non-empty without a valid cluster marker.");
+    return 1;
+  }
+  if (marker_fd < 0) {
+    int result = fail_errno("openat");
+    close(fd);
+    return result;
+  }
+  count = read(marker_fd, contents, sizeof(contents) - 1);
+  close(marker_fd);
+  if (count < 0) {
+    int result = fail_errno("read");
+    close(fd);
+    return result;
+  }
+  contents[count] = '\0';
+  if ((strcmp(contents, version) != 0 &&
+      (count < 1 || contents[count - 1] != '\n' ||
+        strncmp(contents, version, (size_t)count - 1) != 0))) {
+    close(fd);
+    fail_message("The database directory has an incompatible version marker.");
+    return 1;
+  }
+  if (validate_cluster_fd(fd, version) != 0) {
+    close(fd);
+    return 1;
+  }
+  close(fd);
+  puts("present");
+  return 0;
+}
+
+static int command_initialize_cluster(int argc, char **argv) {
+  int fd;
+  int empty;
+  pid_t child;
+  int child_status;
+
+  if (argc < 5) {
+    usage();
+    return 64;
+  }
+  fd = open_exec_directory(argv[1], 1);
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  empty = directory_fd_is_empty(fd);
+  if (empty < 0) {
+    int result = fail_errno("readdir");
+    close(fd);
+    return result;
+  }
+  if (empty == 0) {
+    close(fd);
+    fail_message("The directory is not empty.");
+    return 1;
+  }
+  child = fork();
+  if (child < 0) {
+    int result = fail_errno("fork");
+    close(fd);
+    return result;
+  }
+  if (child == 0) {
+    char **child_argv = calloc((size_t)(argc - 2), sizeof(*child_argv));
+    if (child_argv == NULL) {
+      dprintf(STDERR_FILENO, "calloc: %s\n", strerror(errno));
+      _exit(127);
+    }
+    if (fchdir(fd) < 0) {
+      dprintf(STDERR_FILENO, "fchdir: %s\n", strerror(errno));
+      _exit(127);
+    }
+    child_argv[0] = argv[3];
+    for (int index = 4; index < argc; index++) {
+      child_argv[index - 3] = argv[index];
+    }
+    child_argv[argc - 3] = NULL;
+    execv(argv[3], child_argv);
+    dprintf(STDERR_FILENO, "execv: %s\n", strerror(errno));
+    _exit(127);
+  }
+  if (waitpid(child, &child_status, 0) < 0) {
+    int result = fail_errno("waitpid");
+    close(fd);
+    return result;
+  }
+  if (!WIFEXITED(child_status) || WEXITSTATUS(child_status) != 0) {
+    close(fd);
+    fail_message("The database initializer failed.");
+    return 1;
+  }
+  if (validate_cluster_fd(fd, argv[2]) != 0) {
+    close(fd);
+    return 1;
+  }
+  close(fd);
+  return 0;
+}
+
+static int write_u32(uint32_t value) {
+  unsigned char bytes[4];
+  bytes[0] = (unsigned char)(value & 0xffU);
+  bytes[1] = (unsigned char)((value >> 8) & 0xffU);
+  bytes[2] = (unsigned char)((value >> 16) & 0xffU);
+  bytes[3] = (unsigned char)((value >> 24) & 0xffU);
+  return fwrite(bytes, 1, sizeof(bytes), stdout) == sizeof(bytes) ? 0 : 1;
+}
+
+static int write_u64(uint64_t value) {
+  unsigned char bytes[8];
+  size_t index;
+  for (index = 0; index < sizeof(bytes); index++) {
+    bytes[index] = (unsigned char)((value >> (index * 8)) & 0xffU);
+  }
+  return fwrite(bytes, 1, sizeof(bytes), stdout) == sizeof(bytes) ? 0 : 1;
+}
+
+static int write_bytes(const void *data, size_t length) {
+  return fwrite(data, 1, length, stdout) == length ? 0 : 1;
+}
+
+static int write_snapshot_header(unsigned char kind, mode_t mode, const char *path,
+                                uint64_t data_length) {
+  size_t path_length = strlen(path);
+  if (write_bytes(&kind, 1) != 0 || write_u32((uint32_t)(mode & 07777)) != 0 ||
+      write_u64((uint64_t)path_length) != 0 || write_bytes(path, path_length) != 0 ||
+      write_u64(data_length) != 0) {
+    return fail_errno("write");
+  }
+  return 0;
+}
+
+static char *join_snapshot_path(const char *prefix, const char *name) {
+  size_t prefix_length = strlen(prefix);
+  size_t name_length = strlen(name);
+  char *joined = malloc(prefix_length + 1 + name_length + 1);
+  if (joined == NULL) {
+    errno = ENOMEM;
+    return NULL;
+  }
+  if (strcmp(prefix, ".") == 0) {
+    snprintf(joined, name_length + 2, "./%s", name);
+  } else {
+    memcpy(joined, prefix, prefix_length);
+    joined[prefix_length] = '/';
+    memcpy(joined + prefix_length + 1, name, name_length + 1);
+  }
+  return joined;
+}
+
+static int compare_names(const void *left, const void *right) {
+  const char *const *left_name = left;
+  const char *const *right_name = right;
+  return strcmp(*left_name, *right_name);
+}
+
+static int collect_names(int directory_fd, char ***names_out, size_t *count_out,
+                        struct stat *before, struct stat *after) {
+  int scan_fd;
+  DIR *directory;
+  struct dirent *entry;
+  char **names = NULL;
+  size_t count = 0;
+  size_t capacity = 0;
+
+  if (fstat(directory_fd, before) < 0) {
+    return fail_errno("fstat");
+  }
+  scan_fd = dup(directory_fd);
+  if (scan_fd < 0) {
+    return fail_errno("dup");
+  }
+  directory = fdopendir(scan_fd);
+  if (directory == NULL) {
+    close(scan_fd);
+    return fail_errno("fdopendir");
+  }
+  errno = 0;
+  while ((entry = readdir(directory)) != NULL) {
+    char *name;
+    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+      continue;
+    }
+    if (count == capacity) {
+      size_t new_capacity = capacity == 0 ? 16 : capacity * 2;
+      char **new_names = realloc(names, new_capacity * sizeof(*new_names));
+      if (new_names == NULL) {
+        closedir(directory);
+        for (size_t index = 0; index < count; index++) {
+          free(names[index]);
+        }
+        free(names);
+        errno = ENOMEM;
+        return fail_errno("realloc");
+      }
+      names = new_names;
+      capacity = new_capacity;
+    }
+    name = strdup(entry->d_name);
+    if (name == NULL) {
+      closedir(directory);
+      for (size_t index = 0; index < count; index++) {
+        free(names[index]);
+      }
+      free(names);
+      errno = ENOMEM;
+      return fail_errno("strdup");
+    }
+    names[count++] = name;
+  }
+  if (errno != 0 || fstat(directory_fd, after) < 0) {
+    int saved_errno = errno == 0 ? EIO : errno;
+    closedir(directory);
+    for (size_t index = 0; index < count; index++) {
+      free(names[index]);
+    }
+    free(names);
+    errno = saved_errno;
+    return fail_errno("directory snapshot");
+  }
+  closedir(directory);
+  qsort(names, count, sizeof(*names), compare_names);
+  *names_out = names;
+  *count_out = count;
+  return 0;
+}
+
+static int snapshot_file(int fd, const struct stat *before, const char *path) {
+  unsigned char buffer[65536];
+  uint64_t remaining = (uint64_t)before->st_size;
+  struct stat after;
+
+  if (write_snapshot_header('F', before->st_mode, path, remaining) != 0) {
+    return 1;
+  }
+  while (remaining > 0) {
+    size_t requested = remaining < sizeof(buffer) ? (size_t)remaining : sizeof(buffer);
+    ssize_t count = read(fd, buffer, requested);
+    if (count <= 0 || write_bytes(buffer, (size_t)count) != 0) {
+      return count < 0 ? fail_errno("read") : 1;
+    }
+    remaining -= (uint64_t)count;
+  }
+  {
+    unsigned char extra;
+    ssize_t count = read(fd, &extra, 1);
+    if (count != 0) {
+      fail_message("File changed while it was being snapshotted.");
+      return 1;
+    }
+  }
+  if (fstat(fd, &after) < 0) {
+    return fail_errno("fstat");
+  }
+  if (!stat_matches(before, &after)) {
+    fail_message("File changed while it was being snapshotted.");
+    return 1;
+  }
+  return 0;
+}
+
+static int snapshot_directory(int fd, const char *path) {
+  char **names = NULL;
+  size_t count = 0;
+  struct stat directory_before;
+  struct stat names_before;
+  struct stat after;
+
+  if (fstat(fd, &directory_before) < 0) {
+    return fail_errno("fstat");
+  }
+  if (!S_ISDIR(directory_before.st_mode) || !is_owned_by_user(&directory_before)) {
+    fail_message("Source directory is not an owned real directory.");
+    return 1;
+  }
+  if (write_snapshot_header('D', directory_before.st_mode, path, 0) != 0) {
+    return 1;
+  }
+  if (collect_names(fd, &names, &count, &names_before, &after) != 0) {
+    return 1;
+  }
+  if (!stat_matches(&directory_before, &names_before)) {
+    for (size_t index = 0; index < count; index++) {
+      free(names[index]);
+    }
+    free(names);
+    fail_message("Source directory changed while it was being snapshotted.");
+    return 1;
+  }
+  for (size_t index = 0; index < count; index++) {
+    const char *name = names[index];
+    int child_fd;
+    struct stat child_status;
+    char *child_path;
+
+    child_path = join_snapshot_path(path, name);
+    if (child_path == NULL) {
+      for (size_t cleanup = 0; cleanup < count; cleanup++) {
+        free(names[cleanup]);
+      }
+      free(names);
+      return fail_errno("malloc");
+    }
+    child_fd = open_child(fd, name, 0);
+    if (child_fd < 0) {
+      free(child_path);
+      for (size_t cleanup = 0; cleanup < count; cleanup++) {
+        free(names[cleanup]);
+      }
+      free(names);
+      return fail_errno("openat");
+    }
+    if (fstat(child_fd, &child_status) < 0) {
+      close(child_fd);
+      free(child_path);
+      for (size_t cleanup = 0; cleanup < count; cleanup++) {
+        free(names[cleanup]);
+      }
+      free(names);
+      return fail_errno("fstat");
+    }
+    if (strcmp(name, ".git") == 0 && S_ISDIR(child_status.st_mode)) {
+      close(child_fd);
+      free(child_path);
+      continue;
+    }
+    if (!is_owned_by_user(&child_status) ||
+        (!S_ISREG(child_status.st_mode) && !S_ISDIR(child_status.st_mode))) {
+      close(child_fd);
+      free(child_path);
+      for (size_t cleanup = 0; cleanup < count; cleanup++) {
+        free(names[cleanup]);
+      }
+      free(names);
+      fail_message("Source tree contains a symlink or special file.");
+      return 1;
+    }
+    if (S_ISDIR(child_status.st_mode)) {
+      if (snapshot_directory(child_fd, child_path) != 0) {
+        close(child_fd);
+        free(child_path);
+        for (size_t cleanup = 0; cleanup < count; cleanup++) {
+          free(names[cleanup]);
+        }
+        free(names);
+        return 1;
+      }
+    } else if (snapshot_file(child_fd, &child_status, child_path) != 0) {
+      close(child_fd);
+      free(child_path);
+      for (size_t cleanup = 0; cleanup < count; cleanup++) {
+        free(names[cleanup]);
+      }
+      free(names);
+      return 1;
+    }
+    close(child_fd);
+    free(child_path);
+  }
+  if (fstat(fd, &after) < 0 || !stat_matches(&directory_before, &after)) {
+    for (size_t index = 0; index < count; index++) {
+      free(names[index]);
+    }
+    free(names);
+    fail_message("Source directory changed while it was being snapshotted.");
+    return 1;
+  }
+  for (size_t index = 0; index < count; index++) {
+    free(names[index]);
+  }
+  free(names);
+  return 0;
+}
+
+static int command_snapshot_tree(const char *path) {
+  int fd = open_trusted_path(path, O_DIRECTORY);
+  int result;
+  if (fd < 0) {
+    return fail_errno("openat");
+  }
+  result = snapshot_directory(fd, ".");
+  close(fd);
+  return result;
+}
+
+static void usage(void) {
+  fprintf(stderr, "Usage: local-control-secure-files COMMAND PATH [MODE]\n"
+                  "Commands: ensure-directory, validate-directory, "
+                  "validate-source-directory, "
+                  "validate-file, inspect-file, repair-file-mode, "
+                  "read-file, create-file, atomic-write, directory-empty, "
+                  "validate-cluster, cluster-state, initialize-cluster, exec-cluster, "
+                  "exec-cluster-socket, "
+                  "exec-private-directory, exec-empty-private-directory, exec-source, "
+                  "exec-files, exec-proxy, "
+                  "snapshot-tree\n");
+}
+
+int main(int argc, char **argv) {
+  if (argc < 3) {
+    usage();
+    return 64;
+  }
+  if (strcmp(argv[1], "ensure-directory") == 0 && argc == 3) {
+    return command_ensure_directory(argv[2]);
+  }
+  if (strcmp(argv[1], "validate-directory") == 0 && argc == 3) {
+    return command_validate_directory(argv[2]);
+  }
+  if (strcmp(argv[1], "validate-source-directory") == 0 && argc == 3) {
+    return command_validate_source_directory(argv[2]);
+  }
+  if (strcmp(argv[1], "validate-file") == 0 && argc == 4) {
+    return command_validate_file(argv[2], argv[3], 0);
+  }
+  if (strcmp(argv[1], "inspect-file") == 0 && argc == 4) {
+    return command_validate_file(argv[2], argv[3], 1);
+  }
+  if (strcmp(argv[1], "repair-file-mode") == 0 && argc == 4) {
+    return command_repair_file_mode(argv[2], argv[3]);
+  }
+  if (strcmp(argv[1], "read-file") == 0 && argc == 4) {
+    return command_read_file(argv[2], argv[3]);
+  }
+  if (strcmp(argv[1], "create-file") == 0 && argc == 4) {
+    return command_create_file(argv[2], argv[3]);
+  }
+  if (strcmp(argv[1], "atomic-write") == 0 && argc == 4) {
+    return command_atomic_write(argv[2], argv[3]);
+  }
+  if (strcmp(argv[1], "directory-empty") == 0 && argc == 3) {
+    return command_directory_empty(argv[2]);
+  }
+  if (strcmp(argv[1], "validate-cluster") == 0 && argc == 4) {
+    return command_validate_cluster(argv[2], argv[3]);
+  }
+  if (strcmp(argv[1], "cluster-state") == 0 && argc == 4) {
+    return command_cluster_state(argv[2], argv[3]);
+  }
+  if (strcmp(argv[1], "initialize-cluster") == 0) {
+    return command_initialize_cluster(argc - 1, &argv[1]);
+  }
+  if (strcmp(argv[1], "exec-cluster") == 0) {
+    return command_exec_cluster(argc - 1, &argv[1]);
+  }
+  if (strcmp(argv[1], "exec-cluster-socket") == 0) {
+    return command_exec_cluster_socket(argc - 1, &argv[1]);
+  }
+  if (strcmp(argv[1], "exec-private-directory") == 0 && argc >= 4) {
+    return exec_with_directory(argv[2], 1, argv[3], argc - 4, &argv[4]);
+  }
+  if (strcmp(argv[1], "exec-empty-private-directory") == 0 && argc >= 4) {
+    return exec_with_empty_directory(argv[2], argv[3], argc - 4, &argv[4]);
+  }
+  if (strcmp(argv[1], "exec-source") == 0 && argc >= 4) {
+    return exec_with_directory(argv[2], 0, argv[3], argc - 4, &argv[4]);
+  }
+  if (strcmp(argv[1], "exec-files") == 0) {
+    return command_exec_files(argc - 1, &argv[1]);
+  }
+  if (strcmp(argv[1], "exec-proxy") == 0) {
+    return command_exec_proxy(argc - 1, &argv[1]);
+  }
+  if (strcmp(argv[1], "snapshot-tree") == 0 && argc == 3) {
+    return command_snapshot_tree(argv[2]);
+  }
+  usage();
+  return 64;
+}


### PR DESCRIPTION
- **feat: add private local control services**
- **fix: restore clean Darwin evaluation**
- **chore(deps): update checkout action**
- **feat: add comprehensive flake maintenance commands**
- **fix: preserve native Darwin command behavior**
- **chore: disable unused local services**
- **chore: update flake inputs**
- **update pkgs**
- **feat: add nix-seal foundation submodule**
- **chore: advance nix-seal signed artifacts**
- **chore: advance nix-seal rekey transactions**
- **chore: advance nix-seal activation runtime**
- **chore: repin portable nix-seal runtime**
- **chore: advance nix-seal activation integration**
- **chore: repin formatted nix-seal flake**
- **chore: advance nix-seal ownership enforcement**
- **chore: advance nix-seal service coordination**
- **chore: advance nix-seal credential delivery**
- **chore: advance nix-seal runtime templates**
- **chore: advance nix-seal target policy binding**
- **chore: advance nix-seal verified authoring**
- **chore: advance nix-seal quality gate fix**
- **chore: advance nix-seal recoverable deletion**
- **chore: advance nix-seal cache hardening**
- **chore: advance nix-seal cache gc**
- **chore: update nix-seal cache GC**
- **chore: format nix-seal cache docs**
- **chore: update nix-seal cache exchange**
- **chore: update nix-seal doctor**
- **chore: update nix-seal generator foundation**
- **chore: update nix-seal migration inspection**
- **chore: update nix-seal SSH migration support**
- **chore: update nix-seal multi-output generators**
- **chore: update nix-seal external generators**
- **chore: update nix-seal prompt transport**
- **chore: update nix-seal agenix migration inventory**
- **chore: update nix-seal migration execution**
- **chore: update nix-seal migration root hardening**
- **chore: update nix-seal generator tooling**
- **chore: update nix-seal initialization support**
- **chore: update nix-seal migration validation**
- **chore: update nix-seal migration candidate export**
- **chore: update nix-seal SOPS migration support**
- **chore: update nix-seal Clan Vars migration support**
- **chore: update nix-seal supply-chain policy**
- **chore: update nix-seal SOPS migration**
- **test: update nix-seal SOPS migration coverage**
- **chore: update nix-seal agenix-rekey migration**
- **docs: update nix-seal agenix-rekey migration**
- **chore: update nix-seal Clan Facts migration**
- **docs: update nix-seal Clan Facts migration**
- **docs: update nix-seal supply-chain gates**
- **chore: update nix-seal identity inventory**
- **feat: import nix-seal flake module**
- **chore: update nix-seal identity lifecycle**
- **test: update nix-seal identity collision coverage**
- **chore: update nix-seal group lifecycle**
- **chore: update nix-seal signer validation**
- **docs: update nix-seal group command guidance**
- **chore: update nix-seal routine key validation**
- **chore: update nix-seal compiled-plan validation**
- **chore: update nix-seal template checks**
- **chore: update nix-seal passphrase generator**
- **chore: format nix-seal passphrase documentation**
- **chore: update nix-seal exit categories**
- **chore: format nix-seal exit documentation**
- **feat: add nix-seal to default dev shell**
- **chore: update nix-seal template tooling**
- **chore: update nix-seal direct artifact support**
- **chore: update nix-seal generator policy**
- **chore: update nix-seal SSH generator**
- **chore: update nix-seal generator lifecycle**
- **chore: update nix-seal provisioning**
- **chore: update nix-seal password generation**
- **chore: format nix-seal password guidance**
- **chore: update nix-seal cache retention**
- **chore: update nix-seal doctor diagnostics**
- **chore: format nix-seal doctor documentation**
- **chore: update nix-seal PGP migration**
- **chore: harden nix-seal PGP migration**
- **docs: update nix-seal migration ADR**
- **chore: format nix-seal migration ADR**
- **test: update nix-seal fuzzing foundation**
- **chore: harden nix-seal identity paths**
- **chore: format nix-seal identity checks**
- **chore: harden nix-seal CLI processes**
- **chore: update nix-seal activation phases**
- **chore: format nix-seal integration**
- **chore: pin users phase ordering fix**
- **chore: pin Home Manager phase support**
- **chore: pin nix-darwin phase support**
- **chore: pin generated documentation package**
- **chore: pin activation fuzzing**
- **chore: pin template fuzzing**
- **chore: pin envelope fuzzing**
- **chore: pin identity fuzzing**
- **chore: pin recipient validation**
- **chore: pin approval key validation**
- **chore: pin seeded plan fuzzing**
- **chore: pin cache state fuzzing**
- **chore: pin structured input validation**
- **chore: pin structured edit validation**
- **chore: pin cache fuzz hardening**
- **chore: pin age interoperability checks**
- **chore: pin plugin policy hardening**
- **chore: pin official age vector coverage**
- **chore: lock nix-seal vector corpus**
- **chore: pin runtime link hardening**
- **chore: pin runtime hard-link coverage**
- **chore: pin activation ancestry coverage**
- **chore: pin hardened secret file creation**
- **chore: pin activation lock coverage**
- **chore: update nix-seal dependency policy**
- **test: pin nix-seal runtime VM coverage**
- **style: format nix-seal VM test**
- **fix: pin Linux VM evaluation fix**
- **ci: pin verified nix-seal Scorecard workflow**
- **ci: pin verified nix-seal actions**
- **ci: pin nix-seal CodeQL v4 upgrade**
- **docs: pin nix-seal security reporting update**
- **fix: update nix-seal CI stability fixes**
- **security: update nix-seal reviewed dependency audit**
- **test: pin portable SOPS migration fixture**
- **security: update nix-seal editor hardening**
- **docs: update nix-seal man page checks**
- **ci: update nix-seal cargo-vet metadata**
- **ci: finalize nix-seal cargo-vet formatting**
- **ci: update nix-seal concurrency policy**
- **chore: update nix-seal submodule**
- **chore: update nix-seal submodule**
- **chore: update nix-seal submodule**
- **chore: update nix-seal submodule**
- **chore: update nix-seal submodule**
- **chore: update nix-seal submodule**
- **chore: update nix-seal submodule**
- **chore: update nix-seal submodule**
- **chore: update nix-seal submodule**
- **chore: update nix-seal submodule**
- **chore: pin formatted nix-seal docs**
- **chore: update nix-seal selector support**
- **chore: pin refreshed selector schema**
- **chore: pin Nix module plan compilation**
- **chore: pin persistent prompt support**
- **chore: pin formatted persistent prompt docs**
- **chore: pin public generator outputs**
- **chore: pin formatted public output schema**
- **chore: pin yaml validation support**
- **chore: pin cargo vet formatting fix**
- **fix: harden external process cleanup**
- **style: pin formatted process docs**
- **chore: pin isolated age plugin worker**
- **chore: pin plugin worker cleanup**
- **chore: pin plugin routing tests**
- **chore: pin hardened generator prompts**
- **chore: pin formatted prompt docs**
- **chore: pin prompt buffer hardening**
- **chore: pin prompt documentation**
- **chore: pin generator capability warning**
- **chore: pin threat model update**
- **chore: pin nix-seal generator isolation**
- **chore: pin nix-seal Nix artifact bridge**
- **chore: pin nix-seal artifact formatting**
- **chore: pin nix-seal artifact bridge**
- **chore: pin nix-seal age migration**
- **chore: pin agenix-rekey migration support**
- **chore: pin dependency and lint fixes**
- **chore: pin audited dependency metadata**
- **chore: pin normalized cargo vet audits**
- **chore: pin Clan migration imports**
- **chore: pin secretctl migration**
- **chore: pin benchmark assurance**
- **chore: pin formatted benchmark docs**
- **chore: pin release assurance**
- **chore: pin RustSec audit**
- **docs: pin corrected plan examples**
- **docs: pin recovery runbooks**
- **feat: pin canonical recipient rekey**
- **chore: pin formatted rekey docs**
- **security: pin authorized canonical rekey**
- **test: pin migration compatibility goldens**
- **chore: pin nix-seal authoring authorization**
- **chore: pin nix-seal property and auth checks**
- **chore: pin passphrase recovery identity support**
- **chore: pin recovery identity documentation**
- **chore: pin recovery identity ADR**
- **chore: pin wrapped recovery ADR**
- **chore: pin recovery-path doctor warning**
- **fix: pin mandoc-compatible manpage**
- **pin cache hardening**
- **pin runtime marker hardening**
- **pin descriptor-relative activation**
- **pin descriptor-relative activation docs**
- **pin runtime directory fsync hardening**
- **pin cache state-machine coverage**
- **pin activation state-machine coverage**
- **pin interrupted cache recovery**
- **pin concurrent cache coverage**
- **pin formatted cache roadmap**
- **add nix-seal dogfood flake check**
- **pin cache path hardening**
- **pin formatted cache ADR**
- **exercise secretctl migration in dogfood**
- **pin NixOS credential VM coverage**
- **pin cache publication hardening**
- **pin formatted cache security docs**
- **pin cache roadmap formatting**
- **pin service manager hardening**
- **pin formatted service threat model**
- **pin strict ID path validation**
- **pin strict ID specification**
- **pin declarative credential VM fixture**
- **pin native systemd credential VM unit**
- **pin complete VM credential fixture**
- **pin VM service restart policy**
- **pin complete systemd credential fixture**
- **pin nix-seal ID validation fix**
- **pin secret source normalization fix**
- **pin strict source path validation**
- **pin no-follow ciphertext path hardening**
- **pin portable ciphertext ancestry hardening**
- **pin cache publication race coverage**
- **pin formatted cache race coverage**
- **pin cache race roadmap formatting**
- **dogfood nix-seal end to end in parent flake**
- **pin migration mutation fixtures**
- **pin clippy-safe migration fixtures**
- **pin pending activation hardening**
- **pin formatted activation docs**
- **pin bounded cache read hardening**
- **pin private descriptor hardening**
- **pin descriptor ADR formatting**
- **bump nix-seal authoring hardening**
- **pin formatted nix-seal ADR**
- **pin NixOS installer partitioning support**
- **pin installer documentation formatting**
- **dogfood nix-seal migration in parent flake**
- **update nix-seal submodule**
- **update nix-seal prompt handling**
- **add nix-seal collection authoring**
- **format nix-seal documentation**
- **test nix-seal collection schema**
- **serialize nix-seal repository authoring**
- **ignore nix-seal repository lock**
- **update nix-seal migration hardening**
- **update nix-seal migration collision checks**
- **dogfood secure secretctl migration plan**
- **validate secretctl plans after side-by-side rekey**
- **update nix-seal compatibility symlinks**
- **format nix-seal generated schema**
- **sync formatted nix-seal**
- **test nix-seal compatibility symlink dogfood**
- **update nix-seal SSH agent support**
- **update nix-seal SSH generator outputs**
- **update nix-seal WireGuard generator outputs**
- **update nix-seal submodule**
- **advance nix-seal submodule**
- **update nix-seal submodule**
- **advance nix-seal runtime hardening**
- **advance compatibility path hardening**
- **feat: migrate nix-conf secret integration to nix-seal**
- **feat(secrets): complete nix-seal ciphertext migration**
- **scope nix-seal artifacts to their targets**
- **update nix-seal formatter fixes**
- **update nix-seal documentation formatting**
- **update formatted nix-seal specification**
- **restore nix-seal secrets after reboot and login**
- **restore nix-seal secrets after restart**
- **feat: generate nix-seal deployment lock**
- **Export control release ID to services**
- **refactor: localize lock-free nix-seal policy**
- **refactor: declare nix-seal policy with consumers**
- **fix: use macOS root group for host secret**
- **chore: update nix inputs and Darwin build fixes**
- **chore: update nix-seal volatile Darwin runtime**
- **chore: update nix-seal cleanup fix**
- **chore: update nix-seal Darwin activation fix**
- **chore: update nix-seal tmpfs detection fix**
- **fix(darwin): make optional Spotify signing non-fatal**
- **chore: update nix-seal formatter alignment**
- **chore: update nix-seal CI fixes**
- **chore: update nix-seal platform lint fix**
- **chore: update nix-seal VM test fix**
- **chore: update nix-seal VM fixture fix**
- **chore: update nix-seal VM hash binding**
- **chore: update nix-seal artifact discovery test**
- **chore: update nix-seal warning cleanup**
- **feat: use Linux noswap nix-seal runtime**
- **docs: document Linux volatile runtime**
- **fix: track Linux clippy follow-up**
- **fix: permit Linux user runtime traversal**
- **fix: harden Darwin nix-seal runtime**
- **ci: harden automation and developer tooling (#84)**
- **build(deps)(deps): bump actions/upload-artifact from 4.6.2 to 7.0.1 (#86)**
- **fix: address Copilot review findings (#87)**
- **build(deps)(deps): bump the submodules group with 3 updates (#85)**
- **chore: update nix-seal submodule (#88)**
- **chore: move repository links to Nix Forge (#89)**
- **security: address repository audit findings (#90)**
- **chore: update submodules to latest main (#91)**
- **fix: avoid duplicate Darwin font files (#92)**
- **fix: update nix-seal for Darwin user activation (#93)**
- **local control improvemtns (#94)**
- **fix: forward local control proxy attestation (#95)**
- **chore: update Codex desktop package (#96)**
- **fix: deploy generic local service stack**
- **fix: harden private local service stack**
- **fix: guard local service preparation**
- **fix: make local database validation hermetic**
- **test: validate generic local service setup**
- **fix: harden generic local service deployment**
