### PR TITLE
ci: fix Dependabot merge queue enrollment

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -21,4 +21,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
-        run: gh pr merge "$PR_NUMBER" --repo "$REPOSITORY" --auto --squash --delete-branch
+        run: gh pr merge "$PR_NUMBER" --repo "$REPOSITORY" --auto --squash

--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -21,4 +21,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
-        run: gh pr merge "$PR_NUMBER" --repo "$REPOSITORY" --auto --squash
+        run: |
+          gh pr merge "$PR_NUMBER" --repo "$REPOSITORY" --auto --squash


### PR DESCRIPTION
Remove the incompatible `--delete-branch` flag from the native auto-merge command. GitHub rejects that flag when a merge queue is enabled, so Dependabot PRs never enter the queue. Required checks and all existing branch protections remain unchanged.